### PR TITLE
Remove Builder project and Azure storage references

### DIFF
--- a/ESSFulfilmentService.sln
+++ b/ESSFulfilmentService.sln
@@ -10,8 +10,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ESSFulfilmentService.Tests"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8952EBE4-0805-4D49-89CB-4B83A5E38B99}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ESSFulfilmentService.Builder", "src\ESSFulfilmentService.Builder\ESSFulfilmentService.Builder.csproj", "{32C55259-40B8-408E-AAB8-3B893AC07D8E}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,15 +28,14 @@ Global
 		{B1F6115E-06F5-4775-BAB6-33F645D932E0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B1F6115E-06F5-4775-BAB6-33F645D932E0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B1F6115E-06F5-4775-BAB6-33F645D932E0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{32C55259-40B8-408E-AAB8-3B893AC07D8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{32C55259-40B8-408E-AAB8-3B893AC07D8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{32C55259-40B8-408E-AAB8-3B893AC07D8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{32C55259-40B8-408E-AAB8-3B893AC07D8E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B1F6115E-06F5-4775-BAB6-33F645D932E0} = {8952EBE4-0805-4D49-89CB-4B83A5E38B99}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4B1358AA-DB8A-4916-8DF1-2D186BA98A7F}
 	EndGlobalSection
 EndGlobal

--- a/src/ESSFulfilmentService.AppHost/ESSFulfilmentService.AppHost.csproj
+++ b/src/ESSFulfilmentService.AppHost/ESSFulfilmentService.AppHost.csproj
@@ -18,10 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ESSFulfilmentService.Builder\ESSFulfilmentService.Builder.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="Dockerfile">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/ESSFulfilmentService.AppHost/Program.cs
+++ b/src/ESSFulfilmentService.AppHost/Program.cs
@@ -5,9 +5,7 @@ var storage = builder.AddAzureStorage("storage").RunAsEmulator(
     {
         azurite.WithDataVolume();
     });
-var blobstorage = storage.AddBlobs("blobConnection");
 var queuestorage = storage.AddQueues("queueConnection");
-var tablestorage = storage.AddTables("tableConnection");
 
 
 var iic_custom = builder.AddDockerfile("iic",".")
@@ -15,14 +13,12 @@ var iic_custom = builder.AddDockerfile("iic",".")
 
 var iic_endpoint = iic_custom.GetEndpoint("iic-endpoint");
 
-builder.AddProject<Projects.ESSFulfilmentService_Builder>("essfulfilmentservice-builder")
-    .WithReference(blobstorage)
-    .WaitFor(blobstorage)
-    .WithReference(queuestorage)
-    .WaitFor(queuestorage)
-    .WithReference(tablestorage)
-    .WaitFor(tablestorage)
-    .WithReference(iic_endpoint)
-    .WaitFor(iic_custom);
+// possibly keep#
+// .WithReference(iic_endpoint)
+// .WaitFor(iic_custom)
+
+
+    
+    
 
 builder.Build().Run();


### PR DESCRIPTION
Remove Builder project and Azure storage references

- Updated `ESSFulfilmentService.sln` to remove the `ESSFulfilmentService.Builder` project reference and its associated configuration settings. Added a new `GlobalSection` for `ExtensibilityGlobals` with a `SolutionGuid`.
- Removed the `ESSFulfilmentService.Builder` reference from `ESSFulfilmentService.AppHost.csproj`.
- Cleaned up `Program.cs` by removing Azure storage service references and updated the builder call. Added comments for potential future references to `iic_endpoint` and `iic_custom`.