### PR TITLE
Update Dockerfile to use Tomcat 9.0.102

### DIFF
--- a/src/ESSFulfilmentService.Builder/Dockerfile
+++ b/src/ESSFulfilmentService.Builder/Dockerfile
@@ -9,8 +9,8 @@ RUN dotnet build ./ESSFulfilmentService.Builder.csproj -c $BUILD_CONFIGURATION  
 FROM mcr.microsoft.com/dotnet/runtime:8.0 AS runtime
 RUN apt-get update && apt-get install -y openjdk-17-jdk
 RUN apt-get update && apt-get install -y wget
-RUN wget https://downloads.apache.org/tomcat/tomcat-10/v10.1.39/bin/apache-tomcat-10.1.39.tar.gz && tar -xzvf apache-tomcat-10.1.39.tar.gz && \ 
-mv apache-tomcat-10.1.39 /usr/local/tomcat && rm -rf apache-tomcat-10.1.39.tar.gz && rm -rf /var/lib/apt/lists/*
+RUN wget https://downloads.apache.org/tomcat/tomcat-9/v9.0.102/bin/apache-tomcat-9.0.102.tar.gz && tar -xzvf apache-tomcat-9.0.102.tar.gz && \ 
+mv apache-tomcat-9.0.102 /usr/local/tomcat && rm -rf apache-tomcat-9.0.102.tar.gz && rm -rf /var/lib/apt/lists/*
 COPY xchg-2.4.war /usr/local/tomcat/webapps/
 
 WORKDIR /app
@@ -20,6 +20,7 @@ RUN echo '#!/bin/bash\n' > /startup.sh && \
     echo '/usr/local/tomcat/bin/startup.sh\n' >> /startup.sh && \
     echo 'dotnet /app/ESSFulfilmentService.Builder.dll\n' >> /startup.sh && \
     chmod +x /startup.sh
+
 
 ENTRYPOINT ["bash","/startup.sh"]
 EXPOSE 8080 5000


### PR DESCRIPTION
Update Dockerfile to use Tomcat 9.0.102

Replaced Apache Tomcat version 10.1.39 with 9.0.102.
IIC does not work with Tomcat 10