### PR TITLE
Refactor JobService and update dependencies

### DIFF
--- a/src/UKHO.ADDS.EFS.Orchestrator/Services/JobService.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Services/JobService.cs
@@ -100,9 +100,7 @@ namespace UKHO.ADDS.EFS.Orchestrator.Services
 
         private async Task<(S100SalesCatalogueResponse s100SalesCatalogueResponse, DateTime? scsTimestamp)> GetProductJson(DateTime? timestamp, ExchangeSetRequestQueueMessage message)
         {
-            var timestampString = (timestamp.HasValue && timestamp.Value == DateTime.MinValue) ? string.Empty : timestamp?.ToString("R");
-
-            var s100SalesCatalogueResult = await _salesCatalogueClient.GetS100ProductsFromSpecificDateAsync(ScsApiVersion, ProductType, timestampString!, message.CorrelationId);
+            var s100SalesCatalogueResult = await _salesCatalogueClient.GetS100ProductsFromSpecificDateAsync(ScsApiVersion, ProductType, timestamp, message.CorrelationId);
 
             if (s100SalesCatalogueResult.IsSuccess(out var s100SalesCatalogueData, out var error))
             {

--- a/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetJobTable.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetJobTable.cs
@@ -7,7 +7,7 @@ namespace UKHO.ADDS.EFS.Orchestrator.Tables
     public class ExchangeSetJobTable : BlobTable<ExchangeSetJob>
     {
         public ExchangeSetJobTable(BlobServiceClient blobServiceClient, ILogger<BlobTable<ExchangeSetJob>> logger)
-            : base(blobServiceClient, x => "JobData", x => x.Id, logger)
+            : base(blobServiceClient, x => x.Id, x => x.Id, logger)
         {
         }
     }

--- a/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetJobTable.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetJobTable.cs
@@ -7,7 +7,7 @@ namespace UKHO.ADDS.EFS.Orchestrator.Tables
     public class ExchangeSetJobTable : BlobTable<ExchangeSetJob>
     {
         public ExchangeSetJobTable(BlobServiceClient blobServiceClient, ILogger<BlobTable<ExchangeSetJob>> logger)
-            : base(blobServiceClient, x => x.Id, x => x.Id, logger)
+            : base(blobServiceClient, x => "JobData", x => x.Id, logger)
         {
         }
     }

--- a/src/UKHO.ADDS.EFS.Orchestrator/UKHO.ADDS.EFS.Orchestrator.csproj
+++ b/src/UKHO.ADDS.EFS.Orchestrator/UKHO.ADDS.EFS.Orchestrator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -28,8 +28,8 @@
     <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
-    <PackageReference Include="UKHO.ADDS.Clients.Common" Version="0.0.50415-alpha.1" />
-    <PackageReference Include="UKHO.ADDS.Clients.SalesCatalogueService" Version="0.0.50415-alpha.1" />
+    <PackageReference Include="UKHO.ADDS.Clients.Common" Version="0.0.50422-alpha.3" />
+    <PackageReference Include="UKHO.ADDS.Clients.SalesCatalogueService" Version="0.0.50422-alpha.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/Services/JobServiceTest.cs
+++ b/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/Services/JobServiceTest.cs
@@ -46,7 +46,7 @@ namespace UKHO.ADDS.EFS.Orchestrator.UnitTests.Services
         private void MockSalesCatalogueClientResponse(IResult<S100SalesCatalogueResponse> response)
         {
             A.CallTo(() => _salesCatalogueClient.GetS100ProductsFromSpecificDateAsync(
-                    A<string>.Ignored, A<string>.Ignored, A<string>.Ignored, A<string>.Ignored))
+                    A<string>.Ignored, A<string>.Ignored, A<DateTime>.Ignored, A<string>.Ignored))
                 .Returns(response);
         }
 


### PR DESCRIPTION
Refactor JobService and update dependencies

- Modified `GetProductJson` to pass `timestamp` directly for improved type safety.
- Updated `ExchangeSetJobTable` constructor to use "JobData" as the partition key.
- Upgraded `UKHO.ADDS.Clients.Common` and `UKHO.ADDS.Clients.SalesCatalogueService` package versions for potential enhancements.
- Adjusted unit tests in `JobServiceTest` to align with the new method signature.