### PR TITLE
Miscellaneous : Access modifier changes 

### DIFF
--- a/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/Assemble/CreateBatchNode.cs
+++ b/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/Assemble/CreateBatchNode.cs
@@ -6,7 +6,7 @@ using UKHO.ADDS.Infrastructure.Pipelines.Nodes;
 
 namespace UKHO.ADDS.EFS.Builder.S100.Pipelines.Assemble
 {
-    public class CreateBatchNode : ExchangeSetPipelineNode
+    internal class CreateBatchNode : ExchangeSetPipelineNode
     {
         private readonly IFileShareReadWriteClient _fileShareReadWriteClient;
 

--- a/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/Assemble/ProductSearchNode.cs
+++ b/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/Assemble/ProductSearchNode.cs
@@ -10,7 +10,7 @@ using UKHO.ADDS.Infrastructure.Pipelines.Nodes;
 
 namespace UKHO.ADDS.EFS.Builder.S100.Pipelines.Assemble
 {
-    public class ProductSearchNode : ExchangeSetPipelineNode
+    internal class ProductSearchNode : ExchangeSetPipelineNode
     {
         private readonly IFileShareReadOnlyClient _fileShareReadOnlyClient;
         private ILogger _logger;

--- a/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/ExchangeSetPipelineContext.cs
+++ b/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/ExchangeSetPipelineContext.cs
@@ -7,7 +7,7 @@ using UKHO.ADDS.EFS.Entities;
 
 namespace UKHO.ADDS.EFS.Builder.S100.Pipelines
 {
-    public class ExchangeSetPipelineContext
+    internal class ExchangeSetPipelineContext
     {
         private readonly IConfiguration _configuration;
         private readonly INodeStatusWriter _nodeStatusWriter;

--- a/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/ExchangeSetPipelineNode.cs
+++ b/src/UKHO.ADDS.EFS.Builder.S100/Pipelines/ExchangeSetPipelineNode.cs
@@ -5,7 +5,7 @@ using UKHO.ADDS.Infrastructure.Pipelines.Nodes;
 
 namespace UKHO.ADDS.EFS.Builder.S100.Pipelines
 {
-    public abstract class ExchangeSetPipelineNode : Node<ExchangeSetPipelineContext>
+    internal abstract class ExchangeSetPipelineNode : Node<ExchangeSetPipelineContext>
     {
         protected override void OnAfterExecute(IExecutionContext<ExchangeSetPipelineContext> context)
         {

--- a/src/UKHO.ADDS.EFS.Builder.S100/UKHO.ADDS.EFS.Builder.S100.csproj
+++ b/src/UKHO.ADDS.EFS.Builder.S100/UKHO.ADDS.EFS.Builder.S100.csproj
@@ -16,7 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="UKHO.ADDS.EFS.Builder.S100.Tests" />
+    <InternalsVisibleTo Include="UKHO.ADDS.EFS.Builder.S100.UnitTests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UKHO.ADDS.EFS.Orchestrator/Services/JobService.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Services/JobService.cs
@@ -9,7 +9,7 @@ using UKHO.ADDS.EFS.Orchestrator.Tables;
 
 namespace UKHO.ADDS.EFS.Orchestrator.Services
 {
-    public class JobService
+    internal class JobService
     {
         private const string ScsApiVersion = "v2";
         private const string ProductType = "s100";

--- a/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetJobTable.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetJobTable.cs
@@ -4,7 +4,7 @@ using UKHO.ADDS.EFS.Orchestrator.Tables.Infrastructure;
 
 namespace UKHO.ADDS.EFS.Orchestrator.Tables
 {
-    public class ExchangeSetJobTable : BlobTable<ExchangeSetJob>
+    internal class ExchangeSetJobTable : BlobTable<ExchangeSetJob>
     {
         public ExchangeSetJobTable(BlobServiceClient blobServiceClient, ILogger<BlobTable<ExchangeSetJob>> logger)
             : base(blobServiceClient, x => x.Id, x => x.Id, logger)

--- a/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetTimestampTable.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Tables/ExchangeSetTimestampTable.cs
@@ -4,7 +4,7 @@ using UKHO.ADDS.EFS.Orchestrator.Tables.Infrastructure;
 
 namespace UKHO.ADDS.EFS.Orchestrator.Tables
 {
-    public class ExchangeSetTimestampTable : StructuredTable<ExchangeSetTimestamp>
+    internal class ExchangeSetTimestampTable : StructuredTable<ExchangeSetTimestamp>
     {
         public ExchangeSetTimestampTable(TableServiceClient tableServiceClient)
             : base(tableServiceClient, x => x.DataStandard.ToString().ToLowerInvariant(), x => x.DataStandard.ToString().ToLowerInvariant())

--- a/src/UKHO.ADDS.EFS.Orchestrator/Tables/Infrastructure/BlobTable.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Tables/Infrastructure/BlobTable.cs
@@ -5,7 +5,7 @@ using UKHO.ADDS.Infrastructure.Serialization.Json;
 
 namespace UKHO.ADDS.EFS.Orchestrator.Tables.Infrastructure
 {
-    public abstract class BlobTable<TEntity> : ITable<TEntity> where TEntity : class
+    internal abstract class BlobTable<TEntity> : ITable<TEntity> where TEntity : class
     {
         private readonly BlobServiceClient _blobClient;
 

--- a/src/UKHO.ADDS.EFS.Orchestrator/Tables/Infrastructure/JsonEntity.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Tables/Infrastructure/JsonEntity.cs
@@ -5,7 +5,7 @@ using Azure.Data.Tables;
 
 namespace UKHO.ADDS.EFS.Orchestrator.Tables.Infrastructure
 {
-    public class JsonEntity : ITableEntity
+    internal class JsonEntity : ITableEntity
     {
         public string P0 { get; set; }
         public string P1 { get; set; }

--- a/src/UKHO.ADDS.EFS.Orchestrator/Tables/Infrastructure/StructuredTable.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Tables/Infrastructure/StructuredTable.cs
@@ -5,7 +5,7 @@ using UKHO.ADDS.Infrastructure.Serialization.Json;
 
 namespace UKHO.ADDS.EFS.Orchestrator.Tables.Infrastructure
 {
-    public abstract class StructuredTable<TEntity> : ITable<TEntity> where TEntity : class
+    internal abstract class StructuredTable<TEntity> : ITable<TEntity> where TEntity : class
     {
         private readonly Func<TEntity, string> _partitionKeySelector;
         private readonly Func<TEntity, string> _rowKeySelector;

--- a/src/UKHO.ADDS.EFS.Orchestrator/UKHO.ADDS.EFS.Orchestrator.csproj
+++ b/src/UKHO.ADDS.EFS.Orchestrator/UKHO.ADDS.EFS.Orchestrator.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="UKHO.ADDS.EFS.Orchestrator.UnitTests" />
-    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" PublicKey="0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Restrict class visibility and update project references

### Access Modifier Changes
* Changed classes in `UKHO.ADDS.EFS.Builder.S100` to `internal`:
  - `CreateBatchNode` in `Pipelines/Assemble/CreateBatchNode.cs`
  - `ProductSearchNode` in `Pipelines/Assemble/ProductSearchNode.cs`
  - `ExchangeSetPipelineContext` in `Pipelines/ExchangeSetPipelineContext.cs`
  - `ExchangeSetPipelineNode` in `Pipelines/ExchangeSetPipelineNode.cs`

* Changed classes in `UKHO.ADDS.EFS.Orchestrator` to `internal`:
  - `JobService` in `Services/JobService.cs`
  - `ExchangeSetJobTable` in `Tables/ExchangeSetJobTable.cs`
  - `ExchangeSetTimestampTable` in `Tables/ExchangeSetTimestampTable.cs`
  - `BlobTable` in `Tables/Infrastructure/BlobTable.cs`
  - `JsonEntity` in `Tables/Infrastructure/JsonEntity.cs`
  - `StructuredTable` in `Tables/Infrastructure/StructuredTable.cs`

### Updates to `InternalsVisibleTo`
* Updated `UKHO.ADDS.EFS.Builder.S100.csproj`:
  - Changed `InternalsVisibleTo` from `UKHO.ADDS.EFS.Builder.S100.Tests` to `UKHO.ADDS.EFS.Builder.S100.UnitTests` and added `DynamicProxyGenAssembly2`.

* Updated `UKHO.ADDS.EFS.Orchestrator.csproj`:
  - Removed the `PublicKey` attribute from `DynamicProxyGenAssembly2` to simplify the `InternalsVisibleTo` declaration.
