### PR TITLE
227936 To implement Retry Mechanism on Remaining Endpoints

### DIFF
--- a/src/UKHO.ADDS.EFS.Orchestrator/Services/FileShareService.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Services/FileShareService.cs
@@ -4,6 +4,7 @@ using UKHO.ADDS.Clients.FileShareService.ReadWrite.Models;
 using UKHO.ADDS.Clients.FileShareService.ReadWrite.Models.Response;
 using UKHO.ADDS.EFS.Orchestrator.Logging;
 using UKHO.ADDS.Infrastructure.Results;
+using UKHO.ADDS.EFS.RetryPolicy;
 
 namespace UKHO.ADDS.EFS.Orchestrator.Services
 {
@@ -43,7 +44,9 @@ namespace UKHO.ADDS.EFS.Orchestrator.Services
         /// <returns>A result containing the batch handle on success or error information on failure.</returns>
         public async Task<IResult<IBatchHandle>> CreateBatchAsync(string correlationId, CancellationToken cancellationToken)
         {
-            var createBatchResponseResult = await _fileShareReadWriteClient.CreateBatchAsync(GetBatchModel(), correlationId, cancellationToken);
+            var retryPolicy = HttpRetryPolicyFactory.GetGenericResultRetryPolicy<IBatchHandle>(_logger, nameof(CreateBatchAsync));
+            var createBatchResponseResult = await retryPolicy.ExecuteAsync(() =>
+                _fileShareReadWriteClient.CreateBatchAsync(GetBatchModel(), correlationId, cancellationToken));
             
             if (createBatchResponseResult.IsFailure(out var error, out _))
             {
@@ -62,7 +65,9 @@ namespace UKHO.ADDS.EFS.Orchestrator.Services
         /// <returns>A result containing the commit batch response on success or error information on failure.</returns>
         public async Task<IResult<CommitBatchResponse>> CommitBatchAsync(string batchId, string correlationId, CancellationToken cancellationToken)
         {
-            var commitBatchResult = await _fileShareReadWriteClient.CommitBatchAsync(new BatchHandle(batchId), correlationId, cancellationToken);
+            var retryPolicy = HttpRetryPolicyFactory.GetGenericResultRetryPolicy<CommitBatchResponse>(_logger, nameof(CommitBatchAsync));
+            var commitBatchResult = await retryPolicy.ExecuteAsync(() =>
+                _fileShareReadWriteClient.CommitBatchAsync(new BatchHandle(batchId), correlationId, cancellationToken));
 
             if (commitBatchResult.IsFailure(out var commitError, out _))
             {
@@ -82,8 +87,9 @@ namespace UKHO.ADDS.EFS.Orchestrator.Services
         public async Task<IResult<BatchSearchResponse>> SearchCommittedBatchesExcludingCurrentAsync(string currentBatchId, string correlationId, CancellationToken cancellationToken)
         {
             var filter = $"BusinessUnit eq '{BusinessUnit}' and {ProductTypeQueryClause}$batch(BatchId) ne '{currentBatchId}'";
-
-            var searchResult = await _fileShareReadWriteClient.SearchAsync(filter, Limit, Start, correlationId, cancellationToken);
+            var retryPolicy = HttpRetryPolicyFactory.GetGenericResultRetryPolicy<BatchSearchResponse>(_logger, nameof(SearchCommittedBatchesExcludingCurrentAsync));
+            var searchResult = await retryPolicy.ExecuteAsync(() =>
+                _fileShareReadWriteClient.SearchAsync(filter, Limit, Start, correlationId, cancellationToken));
 
             if (searchResult.IsFailure(out var error, out _))
             {
@@ -117,7 +123,9 @@ namespace UKHO.ADDS.EFS.Orchestrator.Services
 
             foreach (var batch in validBatches)
             {
-                var expiryResult = await _fileShareReadWriteClient.SetExpiryDateAsync(batch.BatchId, new BatchExpiryModel { ExpiryDate = DateTime.UtcNow }, correlationId, cancellationToken);
+                var retryPolicy = HttpRetryPolicyFactory.GetGenericResultRetryPolicy<SetExpiryDateResponse>(_logger, nameof(SetExpiryDateAsync));
+                var expiryResult = await retryPolicy.ExecuteAsync(() =>
+                    _fileShareReadWriteClient.SetExpiryDateAsync(batch.BatchId, new BatchExpiryModel { ExpiryDate = DateTime.UtcNow }, correlationId, cancellationToken));
 
                 if (expiryResult.IsFailure(out var expiryError, out _))
                 {

--- a/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/Services/FileShareServiceTest.cs
+++ b/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/Services/FileShareServiceTest.cs
@@ -21,7 +21,7 @@ namespace UKHO.ADDS.EFS.Orchestrator.UnitTests.Services
         private const string BatchId = "TestBatchId";
 
         [SetUp]
-        public void OneTimeSetUp()
+        public void SetUp()
         {
             _fakeFileShareReadWriteClient = A.Fake<IFileShareReadWriteClient>();
             _logger = A.Fake<ILogger<FileShareService>>();


### PR DESCRIPTION
This draft PR includes changes in the following files to implement the retry logic for the remaining API endpoints:

**Code:**
- FileShareService.cs

**Unit Tests:**
- FileShareServiceTest.cs