### PR TITLE
Basic filtering

### DIFF
--- a/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/Nodes/S100/FilterProductsNode.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/Nodes/S100/FilterProductsNode.cs
@@ -1,0 +1,50 @@
+﻿using StringToExpression.LanguageDefinitions;
+using UKHO.ADDS.Clients.SalesCatalogueService.Models;
+using UKHO.ADDS.EFS.Builds.S100;
+using UKHO.ADDS.EFS.Orchestrator.Jobs;
+using UKHO.ADDS.EFS.Orchestrator.Pipelines.Infrastructure;
+using UKHO.ADDS.EFS.Orchestrator.Pipelines.Infrastructure.Assembly;
+using UKHO.ADDS.Infrastructure.Pipelines;
+using UKHO.ADDS.Infrastructure.Pipelines.Nodes;
+
+namespace UKHO.ADDS.EFS.Orchestrator.Pipelines.Assembly.Nodes.S100
+{
+    internal class FilterProductsNode : AssemblyPipelineNode<S100Build>
+    {
+        private readonly ODataFilterLanguage _language;
+
+        public FilterProductsNode(AssemblyNodeEnvironment nodeEnvironment)
+            : base(nodeEnvironment)
+        {
+            _language = new ODataFilterLanguage();
+        }
+
+        public override Task<bool> ShouldExecuteAsync(IExecutionContext<PipelineContext<S100Build>> context)
+        {
+            var job = context.Subject.Job;
+            var build = context.Subject.Build;
+
+            return Task.FromResult(job.JobState == JobState.Created && !string.IsNullOrEmpty(job.RequestedFilter) && build.Products!.Any());
+        }
+
+        protected override async Task<NodeResultStatus> PerformExecuteAsync(IExecutionContext<PipelineContext<S100Build>> context)
+        {
+            var job = context.Subject.Job;
+            var build = context.Subject.Build;
+
+            var predicate = _language.Parse<S100Products>(job.RequestedFilter);
+            var existingProducts = build.Products!.AsQueryable();
+
+            var filteredProducts = existingProducts.Where(predicate).ToList();
+
+            if (!filteredProducts.Any())
+            {
+                await context.Subject.SignalNoBuildRequired();
+                return NodeResultStatus.Succeeded;
+            }
+
+            build.Products = filteredProducts;
+            return NodeResultStatus.Succeeded;
+        }
+    }
+}

--- a/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/Nodes/S100/GetProductsForDataStandardNode.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/Nodes/S100/GetProductsForDataStandardNode.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using StringToExpression.LanguageDefinitions;
 using UKHO.ADDS.EFS.Builds.S100;
 using UKHO.ADDS.EFS.Orchestrator.Jobs;
 using UKHO.ADDS.EFS.Orchestrator.Pipelines.Infrastructure;

--- a/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/Nodes/S100/GetProductsForDataStandardNode.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/Nodes/S100/GetProductsForDataStandardNode.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using StringToExpression.LanguageDefinitions;
 using UKHO.ADDS.EFS.Builds.S100;
 using UKHO.ADDS.EFS.Orchestrator.Jobs;
 using UKHO.ADDS.EFS.Orchestrator.Pipelines.Infrastructure;

--- a/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/S100AssemblyPipeline.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/S100AssemblyPipeline.cs
@@ -20,6 +20,7 @@ namespace UKHO.ADDS.EFS.Orchestrator.Pipelines.Assembly
             AddPipelineNode<CreateJobNode>(cancellationToken);
             AddPipelineNode<GetDataStandardTimestampNode>(cancellationToken);
             AddPipelineNode<GetProductsForDataStandardNode>(cancellationToken);
+            AddPipelineNode<FilterProductsNode>(cancellationToken);
 
             AddPipelineNode<CreateFileShareBatchNode>(cancellationToken);
             AddPipelineNode<ScheduleBuildNode>(cancellationToken);

--- a/src/UKHO.ADDS.EFS.Orchestrator/UKHO.ADDS.EFS.Orchestrator.csproj
+++ b/src/UKHO.ADDS.EFS.Orchestrator/UKHO.ADDS.EFS.Orchestrator.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Aspire.Azure.Data.Tables" Version="9.3.1" />
     <PackageReference Include="Aspire.Azure.Storage.Queues" Version="9.3.1" />
     <PackageReference Include="Aspire.Azure.Storage.Blobs" Version="9.3.1" />
+    <PackageReference Include="StringToExpression" Version="2.2.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
     <PackageReference Include="UKHO.ADDS.Clients.Common" Version="0.0.50701-alpha.2" />


### PR DESCRIPTION
This pull request introduces a new pipeline node, `FilterProductsNode`, to the `S100AssemblyPipeline` for filtering products based on a specified OData filter. It also includes the necessary dependencies and updates to integrate this node into the pipeline.

### Addition of `FilterProductsNode`:

* **New Node Implementation**: Added a new `FilterProductsNode` class to filter products in the pipeline based on a provided OData filter. This node ensures that only relevant products are included in the build by parsing the filter and applying it to the product list. (`src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/Nodes/S100/FilterProductsNode.cs`)

### Pipeline Integration:

* **Pipeline Update**: Integrated the `FilterProductsNode` into the `S100AssemblyPipeline` by adding it to the sequence of pipeline nodes. (`src/UKHO.ADDS.EFS.Orchestrator/Pipelines/Assembly/S100AssemblyPipeline.cs`)

### Dependency Updates:

* **New Package Reference**: Added a reference to the `StringToExpression` library (version 2.2.0) to enable parsing of OData filters. (`src/UKHO.ADDS.EFS.Orchestrator/UKHO.ADDS.EFS.Orchestrator.csproj`)

