### PR TITLE
Allow scalar UI in Azure dev

### DIFF
--- a/src/UKHO.ADDS.EFS.Orchestrator/Program.cs
+++ b/src/UKHO.ADDS.EFS.Orchestrator/Program.cs
@@ -54,11 +54,11 @@ namespace UKHO.ADDS.EFS.Orchestrator
                 app.UseSerilogRequestLogging();
 
                 // Configure the HTTP request pipeline.
-                if (app.Environment.IsDevelopment())
-                {
+                //if (app.Environment.IsDevelopment())
+                //{
                     app.MapOpenApi();
                     app.MapScalarApiReference(_ => _.Servers = []); // Stop OpenAPI specifying the wrong port in the generated OpenAPI doc
-                }
+                //}
 
                 app.UseMiddleware<CorrelationIdMiddleware>();
                 app.UseMiddleware<ExceptionHandlingMiddleware>();


### PR DESCRIPTION
This pull request modifies the HTTP request pipeline configuration in `Program.cs` to ensure the OpenAPI mapping is always applied, regardless of the environment. The most important change is the removal of the conditional check for the development environment.

### Changes to HTTP request pipeline configuration:

* [`src/UKHO.ADDS.EFS.Orchestrator/Program.cs`](diffhunk://#diff-9f35cfaba066020a6d743ba060258191a8f91b42bc829dafaeb9ae71b28e98b1L57-R61): Removed the `if (app.Environment.IsDevelopment())` condition to ensure `app.MapOpenApi()` and `app.MapScalarApiReference()` are executed in all environments. This change prevents the OpenAPI documentation from being restricted to the development environment and ensures consistent behavior across environments.