### PR TITLE
Add a live deployment  Dockerfile for EFS S100 Builder container called Dockerfile-Release

### DIFF
--- a/src/UKHO.ADDS.EFS.Builder.S100/Dockerfile-Release
+++ b/src/UKHO.ADDS.EFS.Builder.S100/Dockerfile-Release
@@ -1,0 +1,224 @@
+﻿#
+# This dockerfile builds the EFS S100 Builder container. It is based on the Eclipse Temurin JDK 8 base (Ubuntu)
+#
+# It creates the .NET 9 SDK layer and builds the S100 Builder application into /app/build.
+# It downloads and builds the Tomcat source, configures Tomcat and installs the IIC WAR application.
+# Then it copies the .Net build artifacs to /dotnet and sets this as the ENTRYPOINT
+# for the container. 
+#
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+
+ARG BUILD_CONFIGURATION=Release
+
+WORKDIR /src
+
+# Copy and restore projects
+COPY ["UKHO.ADDS.EFS.Builder.S100/UKHO.ADDS.EFS.Builder.S100.csproj", "UKHO.ADDS.EFS.Builder.S100/"]
+COPY ["UKHO.ADDS.EFS.Domain/UKHO.ADDS.EFS.Domain.csproj", "UKHO.ADDS.EFS.Domain/"]
+COPY ["UKHO.ADDS.EFS.Builder.Common/UKHO.ADDS.EFS.Builder.Common.csproj", "UKHO.ADDS.EFS.Builder.Common/"]
+RUN dotnet restore UKHO.ADDS.EFS.Builder.S100/UKHO.ADDS.EFS.Builder.S100.csproj
+
+# Copy remaining files and build
+COPY . .
+WORKDIR /src/UKHO.ADDS.EFS.Builder.S100
+RUN dotnet build UKHO.ADDS.EFS.Builder.S100.csproj -c $BUILD_CONFIGURATION -o /app/build
+
+
+FROM eclipse-temurin:8-jdk-noble AS runtime
+
+ENV CATALINA_HOME=/usr/local/tomcat
+
+ENV PATH=$CATALINA_HOME/bin:$PATH
+
+# CHANGE
+ENV PATH=/app/build:$PATH
+
+RUN mkdir -p "$CATALINA_HOME"
+
+WORKDIR $CATALINA_HOME
+
+# let "Tomcat Native" live somewhere isolated
+ENV TOMCAT_NATIVE_LIBDIR=$CATALINA_HOME/native-jni-lib
+
+ENV LD_LIBRARY_PATH=""
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$TOMCAT_NATIVE_LIBDIR
+
+ENV TOMCAT_MAJOR=9
+ENV TOMCAT_VERSION=9.0.100
+ENV TOMCAT_SHA512=e0b1379866d09b54f2743afb382c32a33bca9652c379467c1fa0a5b15a1b98830ae23fb1d8f96c43148844ce95b6c1d22a66db3f8efaf41f225b158c3cb71c92
+
+RUN set -eux; \
+	\
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		curl \
+		gnupg \
+	; \
+	\
+	ddist() { \
+		local f="$1"; shift; \
+		local distFile="$1"; shift; \
+		local mvnFile="${1:-}"; \
+		local success=; \
+		local distUrl=; \
+		for distUrl in \
+# https://apache.org/history/mirror-history.html
+			"https://dlcdn.apache.org/$distFile" \
+# if the version is outdated, we have to pull from the archive
+			"https://archive.apache.org/dist/$distFile" \
+# if all else fails, let's try Maven (https://www.mail-archive.com/users@tomcat.apache.org/msg134940.html; https://mvnrepository.com/artifact/org.apache.tomcat/tomcat; https://repo1.maven.org/maven2/org/apache/tomcat/tomcat/)
+			${mvnFile:+"https://repo1.maven.org/maven2/org/apache/tomcat/tomcat/$mvnFile"} \
+		; do \
+			if curl -fL -o "$f" "$distUrl" && [ -s "$f" ]; then \
+				success=1; \
+				break; \
+			fi; \
+		done; \
+		[ -n "$success" ]; \
+	}; \
+	\
+	ddist 'tomcat.tar.gz' "tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz" "$TOMCAT_VERSION/tomcat-$TOMCAT_VERSION.tar.gz"; \
+	echo "$TOMCAT_SHA512 *tomcat.tar.gz" | sha512sum --strict --check -; \
+	ddist 'tomcat.tar.gz.asc' "tomcat/tomcat-$TOMCAT_MAJOR/v$TOMCAT_VERSION/bin/apache-tomcat-$TOMCAT_VERSION.tar.gz.asc" "$TOMCAT_VERSION/tomcat-$TOMCAT_VERSION.tar.gz.asc"; \
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+	curl -fL -o upstream-KEYS 'https://www.apache.org/dist/tomcat/tomcat-9/KEYS'; \
+	gpg --batch --import upstream-KEYS; \
+# filter upstream KEYS file to *just* known/precomputed fingerprints
+	printf '' > filtered-KEYS; \
+# see https://www.apache.org/dist/tomcat/tomcat-9/KEYS
+	for key in \
+		'DCFD35E0BF8CA7344752DE8B6FB21E8933C60243' \
+		'A9C5DF4D22E99998D9875A5110C01C5A2F6059E7' \
+		'48F8E69F6390C9F25CFEDCD268248959359E722B' \
+	; do \
+		gpg --batch --fingerprint "$key"; \
+		gpg --batch --export --armor "$key" >> filtered-KEYS; \
+	done; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"; \
+	GNUPGHOME="$(mktemp -d)"; export GNUPGHOME; \
+	gpg --batch --import filtered-KEYS; \
+	gpg --batch --verify tomcat.tar.gz.asc tomcat.tar.gz; \
+	tar -xf tomcat.tar.gz --strip-components=1; \
+	rm bin/*.bat; \
+	rm tomcat.tar.gz*; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"; \
+	\
+# https://tomcat.apache.org/tomcat-9.0-doc/security-howto.html#Default_web_applications
+	mv webapps webapps.dist; \
+	mkdir webapps; \
+# we don't delete them completely because they're frankly a pain to get back for users who do want them, and they're generally tiny (~7MB)
+	\
+	nativeBuildDir="$(mktemp -d)"; \
+	tar -xf bin/tomcat-native.tar.gz -C "$nativeBuildDir" --strip-components=1; \
+	apt-get install -y --no-install-recommends \
+		dpkg-dev \
+		gcc \
+		libapr1-dev \
+		libssl-dev \
+		make \
+	; \
+	( \
+		export CATALINA_HOME="$PWD"; \
+		cd "$nativeBuildDir/native"; \
+		gnuArch="$(dpkg-architecture --query DEB_BUILD_GNU_TYPE)"; \
+		aprConfig="$(command -v apr-1-config)"; \
+		./configure \
+			--build="$gnuArch" \
+			--libdir="$TOMCAT_NATIVE_LIBDIR" \
+			--prefix="$CATALINA_HOME" \
+			--with-apr="$aprConfig" \
+			--with-java-home="$JAVA_HOME" \
+			--with-ssl \
+		; \
+		nproc="$(nproc)"; \
+		make -j "$nproc"; \
+		make install; \
+	); \
+	rm -rf "$nativeBuildDir"; \
+	rm bin/tomcat-native.tar.gz; \
+	\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	find "$TOMCAT_NATIVE_LIBDIR" -type f -executable -exec ldd '{}' ';' \
+		| awk '/=>/ { print $(NF-1) }' \
+		| xargs -rt readlink -e \
+		| sort -u \
+		| xargs -rt dpkg-query --search \
+		| cut -d: -f1 \
+		| sort -u \
+		| tee "$TOMCAT_NATIVE_LIBDIR/.dependencies.txt" \
+		| xargs -r apt-mark manual \
+	; \
+	\
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+# sh removes env vars it doesn't support (ones with periods)
+# https://github.com/docker-library/tomcat/issues/77
+	find ./bin/ -name '*.sh' -exec sed -ri 's|^#!/bin/sh$|#!/usr/bin/env bash|' '{}' +; \
+	\
+# fix permissions (especially for running as non-root)
+# https://github.com/docker-library/tomcat/issues/35
+	chmod -R +rX .; \
+	chmod 1777 logs temp work; \
+	\
+# smoke test
+	catalina.sh version
+
+# verify Tomcat Native is working properly
+RUN set -eux; \
+	nativeLines="$(catalina.sh configtest 2>&1)"; \
+	nativeLines="$(echo "$nativeLines" | grep 'Apache Tomcat Native')"; \
+	nativeLines="$(echo "$nativeLines" | sort -u)"; \
+	if ! echo "$nativeLines" | grep -E 'INFO: Loaded( APR based)? Apache Tomcat Native library' >&2; then \
+		echo >&2 "$nativeLines"; \
+		exit 1; \
+	fi
+
+# copy in war file to webapps for unpacking...
+COPY UKHO.ADDS.EFS.Builder.S100/xchg-2.7.war /usr/local/tomcat/webapps/
+ADD UKHO.ADDS.EFS.Builder.S100/root2.tar.gz /usr/local/tomcat/
+
+
+
+# Add .NET runtime and dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    wget \
+    apt-transport-https \
+    software-properties-common 
+
+# Add Microsoft package signing key
+RUN wget -q https://packages.microsoft.com/keys/microsoft.asc -O /etc/apt/trusted.gpg.d/microsoft.asc
+
+# Note: As of July 2025, official Microsoft package repositories for Ubuntu 24.04 may not be fully signed or supported.
+# noble is the codename for Ubuntu 24.04 LTS ("Noble Numbat"), the distro the IIC tool is installed on
+# For now we must get the runtime from ubuntu 22.04 repository.
+
+RUN wget -q https://packages.microsoft.com/config/ubuntu/22.04/prod.list -O /etc/apt/sources.list.d/dotnetdev.list
+
+
+# Install the .NET runtime 
+RUN apt-get update && \
+    apt-get install -y aspnetcore-runtime-9.0
+
+	
+
+
+
+
+WORKDIR /app
+COPY --from=build /app/build .
+
+
+# It is critical that the container WORKDIR is set to CATALINA_HOME here, or Tomcat will not start properly
+WORKDIR $CATALINA_HOME
+
+ENTRYPOINT ["dotnet", "/app/UKHO.ADDS.EFS.Builder.S100.dll"]
+
+EXPOSE 8080 5000


### PR DESCRIPTION
Add a live deployment  Dockerfile for EFS S100 Builder container called Dockerfile-Release

Install AspNetCore runtime and dependencies
from Ubuntu 22.04 repositories,

This reduces the image size from 1.72 GB to 635 MB