### PR TITLE
Set domains for seeder during deployment

### DIFF
--- a/.azdo/pipelines/azure-pipelines.yml
+++ b/.azdo/pipelines/azure-pipelines.yml
@@ -16,23 +16,23 @@ parameters:
   - name: DeployOrchestrator
     displayName: "Deploy orchestrator"
     type: boolean
-    default: true
+    default: false
   - name: DeployConfiguration
     displayName: "Deploy configuration"
     type: boolean
-    default: true
+    default: false
   - name: DeployBuilderS100
     displayName: "Deploy S100 builder"
     type: boolean
-    default: true
+    default: false
   - name: DeployAddsMock
     displayName: "Deploy ADDS mock"
     type: boolean
-    default: true
+    default: false
   - name: DeployRedis
     displayName: "Deploy Redis"
     type: boolean
-    default: true
+    default: false
   - name: DestroyResourcesDev
     displayName: "Destroy dev environment"
     type: boolean
@@ -80,83 +80,83 @@ resources:
     type: github
 
 stages:
-  - stage: VulnerabilityChecks
-    displayName: "Snyk Checks"
-    dependsOn: []
-    jobs:
-    - template: templates/vulnerability-checks.yml
-      parameters:
-        SnykOnlyFailIfFixable: ${{ parameters.SnykOnlyFailIfFixable }}
-        SnykPassOnIssues: ${{ parameters.SnykPassOnIssues }}
+  # - stage: VulnerabilityChecks
+  #   displayName: "Snyk Checks"
+  #   dependsOn: []
+  #   jobs:
+  #   - template: templates/vulnerability-checks.yml
+  #     parameters:
+  #       SnykOnlyFailIfFixable: ${{ parameters.SnykOnlyFailIfFixable }}
+  #       SnykPassOnIssues: ${{ parameters.SnykPassOnIssues }}
 
-  - stage: Stryker_Mutator
-    displayName: "Stryker Mutator"
-    condition: eq('${{ parameters.DisableStryker }}', false)
-    dependsOn: []
-    jobs:
-    - job: Stryker
-      workspace:
-        clean: all
-      steps:
-        - checkout: self
-          clean: true
+  # - stage: Stryker_Mutator
+  #   displayName: "Stryker Mutator"
+  #   condition: eq('${{ parameters.DisableStryker }}', false)
+  #   dependsOn: []
+  #   jobs:
+  #   - job: Stryker
+  #     workspace:
+  #       clean: all
+  #     steps:
+  #       - checkout: self
+  #         clean: true
 
-        - script: git submodule update --init --recursive
-          displayName: Restore mock submodule
-          workingDirectory: '$(Build.SourcesDirectory)'
+  #       - script: git submodule update --init --recursive
+  #         displayName: Restore mock submodule
+  #         workingDirectory: '$(Build.SourcesDirectory)'
 
-        - task: UseDotNet@2
-          displayName: 'Use .NET SDK for Stryker'
-          inputs:
-            packageType: sdk
-            version: $(SdkVersion)
+  #       - task: UseDotNet@2
+  #         displayName: 'Use .NET SDK for Stryker'
+  #         inputs:
+  #           packageType: sdk
+  #           version: $(SdkVersion)
 
-        - task: DotNetCoreCLI@2
-          displayName: "Install Stryker"
-          inputs:
-            command: custom
-            custom: tool
-            workingDirectory: $(Agent.TempDirectory)
-            arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools
+  #       - task: DotNetCoreCLI@2
+  #         displayName: "Install Stryker"
+  #         inputs:
+  #           command: custom
+  #           custom: tool
+  #           workingDirectory: $(Agent.TempDirectory)
+  #           arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools
 
-        - task: Powershell@2
-          displayName: "Run Stryker for EFS Orchestrator UnitTests"
-          inputs:
-            workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests'
-            targetType: 'inline'
-            pwsh: true
-            script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/UKHO.ADDS.EFS.Orchestrator.UnitTests.csproj --project UKHO.ADDS.EFS.Orchestrator.csproj
+  #       - task: Powershell@2
+  #         displayName: "Run Stryker for EFS Orchestrator UnitTests"
+  #         inputs:
+  #           workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests'
+  #           targetType: 'inline'
+  #           pwsh: true
+  #           script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/UKHO.ADDS.EFS.Orchestrator.UnitTests.csproj --project UKHO.ADDS.EFS.Orchestrator.csproj
 
-        - task: PublishMutationReport@0
-          displayName: 'Publish Strkyer Mutator Report'
-          inputs:
-            reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/**/mutation-report.html'
-            reportDisplayName: 'EFS Orchestrator UnitTests'
+  #       - task: PublishMutationReport@0
+  #         displayName: 'Publish Strkyer Mutator Report'
+  #         inputs:
+  #           reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/**/mutation-report.html'
+  #           reportDisplayName: 'EFS Orchestrator UnitTests'
 
-        - task: Powershell@2
-          displayName: "Run Stryker for EFS Builder S100 UnitTests"
-          inputs:
-            workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests'
-            targetType: 'inline'
-            pwsh: true
-            script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/UKHO.ADDS.EFS.Builder.S100.UnitTests.csproj --project UKHO.ADDS.EFS.Builder.S100.csproj
+  #       - task: Powershell@2
+  #         displayName: "Run Stryker for EFS Builder S100 UnitTests"
+  #         inputs:
+  #           workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests'
+  #           targetType: 'inline'
+  #           pwsh: true
+  #           script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/UKHO.ADDS.EFS.Builder.S100.UnitTests.csproj --project UKHO.ADDS.EFS.Builder.S100.csproj
 
-        - task: PublishMutationReport@0
-          displayName: 'Publish Strkyer Mutator Report'
-          inputs:
-            reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/**/mutation-report.html'
-            reportDisplayName: 'EFS Builder S100 UnitTests'
+  #       - task: PublishMutationReport@0
+  #         displayName: 'Publish Strkyer Mutator Report'
+  #         inputs:
+  #           reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/**/mutation-report.html'
+  #           reportDisplayName: 'EFS Builder S100 UnitTests'
 
-  - stage: Test
-    displayName: Test
-    dependsOn: []
-    jobs:
-    - template: templates/test.yml
+  # - stage: Test
+  #   displayName: Test
+  #   dependsOn: []
+  #   jobs:
+  #   - template: templates/test.yml
 
   - stage: DevDeploy
-    dependsOn:
-    - VulnerabilityChecks
-    - Test
+    dependsOn: []
+    # - VulnerabilityChecks
+    # - Test
     displayName: Dev deploy
     jobs:
     - template: templates/continuous-deployment.yml

--- a/.azdo/pipelines/azure-pipelines.yml
+++ b/.azdo/pipelines/azure-pipelines.yml
@@ -16,23 +16,23 @@ parameters:
   - name: DeployOrchestrator
     displayName: "Deploy orchestrator"
     type: boolean
-    default: false
+    default: true
   - name: DeployConfiguration
     displayName: "Deploy configuration"
     type: boolean
-    default: false
+    default: true
   - name: DeployBuilderS100
     displayName: "Deploy S100 builder"
     type: boolean
-    default: false
+    default: true
   - name: DeployAddsMock
     displayName: "Deploy ADDS mock"
     type: boolean
-    default: false
+    default: true
   - name: DeployRedis
     displayName: "Deploy Redis"
     type: boolean
-    default: false
+    default: true
   - name: DestroyResourcesDev
     displayName: "Destroy dev environment"
     type: boolean
@@ -80,83 +80,83 @@ resources:
     type: github
 
 stages:
-  # - stage: VulnerabilityChecks
-  #   displayName: "Snyk Checks"
-  #   dependsOn: []
-  #   jobs:
-  #   - template: templates/vulnerability-checks.yml
-  #     parameters:
-  #       SnykOnlyFailIfFixable: ${{ parameters.SnykOnlyFailIfFixable }}
-  #       SnykPassOnIssues: ${{ parameters.SnykPassOnIssues }}
+  - stage: VulnerabilityChecks
+    displayName: "Snyk Checks"
+    dependsOn: []
+    jobs:
+    - template: templates/vulnerability-checks.yml
+      parameters:
+        SnykOnlyFailIfFixable: ${{ parameters.SnykOnlyFailIfFixable }}
+        SnykPassOnIssues: ${{ parameters.SnykPassOnIssues }}
 
-  # - stage: Stryker_Mutator
-  #   displayName: "Stryker Mutator"
-  #   condition: eq('${{ parameters.DisableStryker }}', false)
-  #   dependsOn: []
-  #   jobs:
-  #   - job: Stryker
-  #     workspace:
-  #       clean: all
-  #     steps:
-  #       - checkout: self
-  #         clean: true
+  - stage: Stryker_Mutator
+    displayName: "Stryker Mutator"
+    condition: eq('${{ parameters.DisableStryker }}', false)
+    dependsOn: []
+    jobs:
+    - job: Stryker
+      workspace:
+        clean: all
+      steps:
+        - checkout: self
+          clean: true
 
-  #       - script: git submodule update --init --recursive
-  #         displayName: Restore mock submodule
-  #         workingDirectory: '$(Build.SourcesDirectory)'
+        - script: git submodule update --init --recursive
+          displayName: Restore mock submodule
+          workingDirectory: '$(Build.SourcesDirectory)'
 
-  #       - task: UseDotNet@2
-  #         displayName: 'Use .NET SDK for Stryker'
-  #         inputs:
-  #           packageType: sdk
-  #           version: $(SdkVersion)
+        - task: UseDotNet@2
+          displayName: 'Use .NET SDK for Stryker'
+          inputs:
+            packageType: sdk
+            version: $(SdkVersion)
 
-  #       - task: DotNetCoreCLI@2
-  #         displayName: "Install Stryker"
-  #         inputs:
-  #           command: custom
-  #           custom: tool
-  #           workingDirectory: $(Agent.TempDirectory)
-  #           arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools
+        - task: DotNetCoreCLI@2
+          displayName: "Install Stryker"
+          inputs:
+            command: custom
+            custom: tool
+            workingDirectory: $(Agent.TempDirectory)
+            arguments: install dotnet-stryker --tool-path $(Agent.BuildDirectory)/tools
 
-  #       - task: Powershell@2
-  #         displayName: "Run Stryker for EFS Orchestrator UnitTests"
-  #         inputs:
-  #           workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests'
-  #           targetType: 'inline'
-  #           pwsh: true
-  #           script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/UKHO.ADDS.EFS.Orchestrator.UnitTests.csproj --project UKHO.ADDS.EFS.Orchestrator.csproj
+        - task: Powershell@2
+          displayName: "Run Stryker for EFS Orchestrator UnitTests"
+          inputs:
+            workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests'
+            targetType: 'inline'
+            pwsh: true
+            script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/UKHO.ADDS.EFS.Orchestrator.UnitTests.csproj --project UKHO.ADDS.EFS.Orchestrator.csproj
 
-  #       - task: PublishMutationReport@0
-  #         displayName: 'Publish Strkyer Mutator Report'
-  #         inputs:
-  #           reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/**/mutation-report.html'
-  #           reportDisplayName: 'EFS Orchestrator UnitTests'
+        - task: PublishMutationReport@0
+          displayName: 'Publish Strkyer Mutator Report'
+          inputs:
+            reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Orchestrator.UnitTests/**/mutation-report.html'
+            reportDisplayName: 'EFS Orchestrator UnitTests'
 
-  #       - task: Powershell@2
-  #         displayName: "Run Stryker for EFS Builder S100 UnitTests"
-  #         inputs:
-  #           workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests'
-  #           targetType: 'inline'
-  #           pwsh: true
-  #           script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/UKHO.ADDS.EFS.Builder.S100.UnitTests.csproj --project UKHO.ADDS.EFS.Builder.S100.csproj
+        - task: Powershell@2
+          displayName: "Run Stryker for EFS Builder S100 UnitTests"
+          inputs:
+            workingDirectory: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests'
+            targetType: 'inline'
+            pwsh: true
+            script: $(Agent.BuildDirectory)/tools/dotnet-stryker --test-project $(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/UKHO.ADDS.EFS.Builder.S100.UnitTests.csproj --project UKHO.ADDS.EFS.Builder.S100.csproj
 
-  #       - task: PublishMutationReport@0
-  #         displayName: 'Publish Strkyer Mutator Report'
-  #         inputs:
-  #           reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/**/mutation-report.html'
-  #           reportDisplayName: 'EFS Builder S100 UnitTests'
+        - task: PublishMutationReport@0
+          displayName: 'Publish Strkyer Mutator Report'
+          inputs:
+            reportPattern: '$(Build.SourcesDirectory)/test/UKHO.ADDS.EFS.Builder.S100.UnitTests/**/mutation-report.html'
+            reportDisplayName: 'EFS Builder S100 UnitTests'
 
-  # - stage: Test
-  #   displayName: Test
-  #   dependsOn: []
-  #   jobs:
-  #   - template: templates/test.yml
+  - stage: Test
+    displayName: Test
+    dependsOn: []
+    jobs:
+    - template: templates/test.yml
 
   - stage: DevDeploy
-    dependsOn: []
-    # - VulnerabilityChecks
-    # - Test
+    dependsOn:
+    - VulnerabilityChecks
+    - Test
     displayName: Dev deploy
     jobs:
     - template: templates/continuous-deployment.yml

--- a/.azdo/pipelines/templates/continuous-deployment.yml
+++ b/.azdo/pipelines/templates/continuous-deployment.yml
@@ -172,7 +172,7 @@ jobs:
                   echo "--------------------------------------------------------------------------------"
                 fi
 
-                dotnet run --project $(Build.SourcesDirectory)/efs/config/repo/src/UKHO.ADDS.Configuration.Seeder/UKHO.ADDS.Configuration.Seeder.csproj --configuration Release --no-restore -- "$(AZURE_ENV_NAME)" "$(Build.SourcesDirectory)/efs/config/configuration.json" "$(Build.SourcesDirectory)/efs/config/external-service-disco.json" "$ADDS_CON_WAS_TABLEENDPOINT"
+                dotnet run --project $(Build.SourcesDirectory)/efs/config/UKHO.ADDS.Configuration.Seeder/UKHO.ADDS.Configuration.Seeder.csproj --configuration Release --no-restore -- "$(AZURE_ENV_NAME)" "$(Build.SourcesDirectory)/efs/config/configuration.json" "$(Build.SourcesDirectory)/efs/config/external-service-disco.json" "$ADDS_CON_WAS_TABLEENDPOINT"
             env:
               AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
               AZURE_ENV_NAME: $(AZURE_ENV_NAME)

--- a/.azdo/pipelines/templates/continuous-deployment.yml
+++ b/.azdo/pipelines/templates/continuous-deployment.yml
@@ -172,6 +172,9 @@ jobs:
                   echo "--------------------------------------------------------------------------------"
                 fi
 
+                sed -i "s/{{cae_domain}}/${AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}/g" "$(Build.SourcesDirectory)/efs/config/external-service-disco.json"
+                cat "$(Build.SourcesDirectory)/efs/config/external-service-disco.json"
+
                 dotnet run --project $(Build.SourcesDirectory)/efs/config/UKHO.ADDS.Configuration.Seeder/UKHO.ADDS.Configuration.Seeder.csproj --configuration Release --no-restore -- "$(AZURE_ENV_NAME)" "$(Build.SourcesDirectory)/efs/config/configuration.json" "$(Build.SourcesDirectory)/efs/config/external-service-disco.json" "$ADDS_CON_WAS_TABLEENDPOINT"
             env:
               AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)

--- a/.azdo/pipelines/templates/continuous-deployment.yml
+++ b/.azdo/pipelines/templates/continuous-deployment.yml
@@ -173,7 +173,13 @@ jobs:
                 fi
 
                 sed -i "s/{{cae_domain}}/${AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}/g" "$(Build.SourcesDirectory)/efs/config/external-service-disco.json"
-                cat "$(Build.SourcesDirectory)/efs/config/external-service-disco.json"
+
+                if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
+                  echo "external-service-disco.json:"
+                  echo "--------------------------------------------------------------------------------"
+                  cat "$(Build.SourcesDirectory)/efs/config/external-service-disco.json"
+                  echo "--------------------------------------------------------------------------------"
+                fi
 
                 dotnet run --project $(Build.SourcesDirectory)/efs/config/UKHO.ADDS.Configuration.Seeder/UKHO.ADDS.Configuration.Seeder.csproj --configuration Release --no-restore -- "$(AZURE_ENV_NAME)" "$(Build.SourcesDirectory)/efs/config/configuration.json" "$(Build.SourcesDirectory)/efs/config/external-service-disco.json" "$ADDS_CON_WAS_TABLEENDPOINT"
             env:

--- a/config/external-service-disco.json
+++ b/config/external-service-disco.json
@@ -8,11 +8,11 @@
         "s57SalesCatalogue": "http://{{adds-mocks-efs}}/scs6357/" 
     },
     "dev": {
-        "s100FileShare": "https://adds-mocks-efs.orangesea-886b6e8e.uksouth.azurecontainerapps.io/fss/",
-        "s100SalesCatalogue": "https://adds-mocks-efs.orangesea-886b6e8e.uksouth.azurecontainerapps.io/scs/",
-        "s63FileShare": "https://adds-mocks-efs.orangesea-886b6e8e.uksouth.azurecontainerapps.io/fss6357/",
-        "s63SalesCatalogue": "https://adds-mocks-efs.orangesea-886b6e8e.uksouth.azurecontainerapps.io/scs6357/",
-        "s57FileShare": "https://adds-mocks-efs.orangesea-886b6e8e.uksouth.azurecontainerapps.io/fss6357/",
-        "s57SalesCatalogue": "https://adds-mocks-efs.orangesea-886b6e8e.uksouth.azurecontainerapps.io/scs6357/"
+        "s100FileShare": "https://adds-mocks-efs.{{cae_domain}}/fss/",
+        "s100SalesCatalogue": "https://adds-mocks-efs.{{cae_domain}}/scs/",
+        "s63FileShare": "https://adds-mocks-efs.{{cae_domain}}/fss6357/",
+        "s63SalesCatalogue": "https://adds-mocks-efs.{{cae_domain}}/scs6357/",
+        "s57FileShare": "https://adds-mocks-efs.{{cae_domain}}/fss6357/",
+        "s57SalesCatalogue": "https://adds-mocks-efs.{{cae_domain}}/scs6357/"
     }
 }


### PR DESCRIPTION
#### PR Classification
Enhancement of configuration management for deployment.

#### PR Summary
This pull request updates the deployment configuration to allow dynamic domain configuration and improves debugging capabilities. 
- `continuous-deployment.yml`: Added command to replace `{{cae_domain}}` in `external-service-disco.json` and included debugging output for the file.
- `external-service-disco.json`: Replaced hardcoded URLs with the `{{cae_domain}}` placeholder for flexible domain configuration.
