### PR TITLE
Re-introduce clientId

### DIFF
--- a/configuration/UKHO.ADDS.Aspire.Configuration.Seeder/Json/ExternalServiceDefinitionParser.cs
+++ b/configuration/UKHO.ADDS.Aspire.Configuration.Seeder/Json/ExternalServiceDefinitionParser.cs
@@ -31,6 +31,13 @@ namespace UKHO.ADDS.Aspire.Configuration.Seeder.Json
                     throw new InvalidDataException($"Service '{serviceName}' must have at least one endpoint.");
                 }
 
+                if (!serviceObject.TryGetProperty("clientId", out var clientIdElement))
+                {
+                    throw new InvalidDataException($"Service '{serviceName}' is missing required 'clientId' field.");
+                }
+
+                var clientId = clientIdElement.GetString() ?? throw new InvalidDataException($"clientId for '{serviceName}' is null");
+
                 var serviceEndpoints = new List<ExternalEndpointTemplate>();
                 var hasDefaultTag = false;
 
@@ -99,7 +106,8 @@ namespace UKHO.ADDS.Aspire.Configuration.Seeder.Json
                 results.Add(new ExternalServiceDefinition
                 {
                     Service = serviceName,
-                    Endpoints = serviceEndpoints
+                    Endpoints = serviceEndpoints,
+                    ClientId = clientId
                 });
             }
 

--- a/configuration/UKHO.ADDS.Aspire.Configuration/Remote/ExternalServiceDefinition.cs
+++ b/configuration/UKHO.ADDS.Aspire.Configuration/Remote/ExternalServiceDefinition.cs
@@ -3,6 +3,9 @@
     internal class ExternalServiceDefinition
     {
         public string Service { get; init; } = string.Empty;
+
+        public string ClientId { get; init; } = string.Empty;
+
         public List<ExternalEndpointTemplate> Endpoints { get; init; } = new();
     }
 }

--- a/configuration/external-services.json
+++ b/configuration/external-services.json
@@ -10,7 +10,8 @@
                     "url": "http://{{adds-mocks-efs}}/fss6357/",
                     "tag": "legacy"
                 }
-            ]
+            ],
+            "clientId": "mock"
         },
         "SalesCatalogue": {
             "endpoints": [
@@ -22,7 +23,8 @@
                     "url": "http://{{adds-mocks-efs}}/scs6357/",
                     "tag": "legacy"
                 }
-            ]
+            ],
+            "clientId": "mock"
         }
     },
     "dev": {
@@ -36,7 +38,8 @@
                     "url": "https://adds-mocks-efs.{{cae_domain}}/fss6357/",
                     "tag": "legacy"
                 }
-            ]
+            ],
+            "clientId": "mock"
         },
         "SalesCatalogue": {
             "endpoints": [
@@ -48,7 +51,8 @@
                     "url": "https://adds-mocks-efs.{{cae_domain}}/scs6357/",
                     "tag": "legacy"
                 }
-            ]
+            ],
+            "clientId": "mock"
         }
     },
     "vni": {
@@ -67,7 +71,8 @@
                     "url": "https://salescataloguevnextiat.ukho.gov.uk",
                     "tag": ""
                 }
-            ]
+            ],
+            "clientId": "87158d61-0d84-40c1-af53-5dcebb2e8543"
         }
     },
     "vne": {
@@ -86,7 +91,8 @@
                     "url": "https://salescataloguevnexte2e.ukho.gov.uk",
                     "tag": ""
                 }
-            ]
+            ],
+            "clientId": "87158d61-0d84-40c1-af53-5dcebb2e8543"
         }
     },
     "iat": {
@@ -105,7 +111,8 @@
                     "url": "https://salescatalogueiat.ukho.gov.uk",
                     "tag": ""
                 }
-            ]
+            ],
+            "clientId": "87158d61-0d84-40c1-af53-5dcebb2e8543"
         }
     }
 }


### PR DESCRIPTION
This pull request adds support for a required `clientId` field in external service definitions, ensuring that each service entry in the configuration includes this field and that it is parsed, validated, and made available in the codebase. The changes update both the configuration schema and the related parsing logic to enforce and utilize this new requirement.

**Configuration schema and data updates:**

* Added a required `clientId` field to each external service entry in `external-services.json` for all environments, with appropriate values set for each service. [[1]](diffhunk://#diff-550b50e18d53cb91f73d432d18e91c5d9bee6abfe6af360d6a8288289c8247a2L13-R14) [[2]](diffhunk://#diff-550b50e18d53cb91f73d432d18e91c5d9bee6abfe6af360d6a8288289c8247a2L25-R27) [[3]](diffhunk://#diff-550b50e18d53cb91f73d432d18e91c5d9bee6abfe6af360d6a8288289c8247a2L39-R42) [[4]](diffhunk://#diff-550b50e18d53cb91f73d432d18e91c5d9bee6abfe6af360d6a8288289c8247a2L51-R55) [[5]](diffhunk://#diff-550b50e18d53cb91f73d432d18e91c5d9bee6abfe6af360d6a8288289c8247a2L70-R75) [[6]](diffhunk://#diff-550b50e18d53cb91f73d432d18e91c5d9bee6abfe6af360d6a8288289c8247a2L89-R95) [[7]](diffhunk://#diff-550b50e18d53cb91f73d432d18e91c5d9bee6abfe6af360d6a8288289c8247a2L108-R115)

**Parsing and validation logic:**

* Updated `ExternalServiceDefinitionParser.cs` to require the `clientId` field when parsing service definitions, throwing an error if missing or null, and storing the value in the parsed result. [[1]](diffhunk://#diff-0983138a8d55efd3fa85c7fd780cbc045319e0d70e7165bbfed3f068abbe9c09R34-R40) [[2]](diffhunk://#diff-0983138a8d55efd3fa85c7fd780cbc045319e0d70e7165bbfed3f068abbe9c09L102-R110)

**Data model changes:**

* Added a `ClientId` property to the `ExternalServiceDefinition` class to hold the parsed value.