### PR TITLE
Split pipeline in two

### DIFF
--- a/.azdo/pipelines/azure-pipelines-admin.yml
+++ b/.azdo/pipelines/azure-pipelines-admin.yml
@@ -1,0 +1,167 @@
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd).$(BuildCounter)
+
+parameters:
+- name: SnykOnlyFailIfFixable
+  displayName: "Snyk - fail only if an issue has an available fix"
+  type: boolean
+  default: false
+- name: SnykPassOnIssues
+  displayName: "Snyk - don't fail if issues found"
+  type: boolean
+  default: false
+- name: DeployPermanentResources
+  displayName: "Deploy permanent resources"
+  type: boolean
+  default: false
+- name: DestroyResourcesDev
+  displayName: "Destroy dev environment"
+  type: boolean
+  default: false
+- name: DestroyResourcesVni
+  displayName: "Destroy vNext IAT environment"
+  type: boolean
+  default: false
+- name: DestroyResourcesVne
+  displayName: "Destroy vNext E2E environment"
+  type: boolean
+  default: false
+- name: DestroyResourcesIat
+  displayName: "Destroy IAT environment"
+  type: boolean
+  default: false
+- name: DestroyResourcesPreProd
+  displayName: "Destroy PreProd environment (enter \"iamsure\" to destroy)"
+  type: string
+  default: "No"
+- name: DestroyResourcesLive
+  displayName: "Destroy Live environment (enter \"iamreallysure\" to destroy)"
+  type: string
+  default: "No"
+- name: AdditionalDebugging
+  displayName: "Enable optional pipeline debugging"
+  type: boolean
+  default: false
+
+trigger: none
+
+pool: "Mare Nectaris"
+
+variables:
+- name: BuildCounter
+  value: $[counter(format('{0:yyyyMMdd}', pipeline.startTime), 1)]
+- name: WindowsPool
+  value: "Mare Nubium"
+- name: snykAbzuOrganizationId
+  value: aeb7543b-8394-457c-8334-a31493d8910d
+
+stages:
+- stage: VulnerabilityChecks
+  displayName: "Snyk Checks"
+  dependsOn: []
+  jobs:
+  - template: templates/vulnerability-checks.yml
+    parameters:
+      SnykOnlyFailIfFixable: ${{ parameters.SnykOnlyFailIfFixable }}
+      SnykPassOnIssues: ${{ parameters.SnykPassOnIssues }}
+      IacOnly: true
+
+- ${{ if eq(parameters.DeployPermanentResources, true) }}:
+
+  - stage: DevDeploy
+    dependsOn:
+    - VulnerabilityChecks
+    displayName: Dev deploy
+    jobs:
+    - template: templates/continuous-deployment-retain.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-Dev
+        ShortName: dev
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+
+  - stage: vNextIatDeploy
+    dependsOn:
+    - DevDeploy
+    displayName: vNext IAT Deploy
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/dev/')))
+    jobs:
+    - template: templates/continuous-deployment-retain.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-vnextiat
+        ShortName: vnextiat
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+
+  - stage: vNextE2eDeploy
+    dependsOn:
+    - vNextIatDeploy
+    displayName: vNext E2E Deploy
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
+    jobs:
+    - template: templates/continuous-deployment-retain.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-vnexte2e
+        ShortName: vnexte2e
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+
+  - stage: IatDeploy
+    dependsOn:
+    - DevDeploy
+    displayName: IAT Deploy
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+    jobs:
+    - template: templates/continuous-deployment-retain.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-Iat
+        ShortName: iat
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+
+- ${{ if eq(parameters.DestroyResourcesDev, true) }}:
+
+  - stage: DevDestroy
+    dependsOn:
+    - VulnerabilityChecks
+    displayName: Dev destroy
+    jobs:
+    - template: templates/destroy-infrastructure.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-Dev
+        ShortName: dev
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+
+- ${{ if eq(parameters.DestroyResourcesVni, true) }}:
+
+  - stage: vNextIatDestroy
+    dependsOn:
+    - VulnerabilityChecks
+    displayName: vNext IAT destroy
+    jobs:
+    - template: templates/destroy-infrastructure.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-vnextiat
+        ShortName: vnextiat
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+
+- ${{ if eq(parameters.DestroyResourcesVne, true) }}:
+
+  - stage: vNextE2eDestroy
+    dependsOn:
+    - VulnerabilityChecks
+    displayName: vNext E2E destroy
+    jobs:
+    - template: templates/destroy-infrastructure.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-vnexte2e
+        ShortName: vnexte2e
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+
+- ${{ if eq(parameters.DestroyResourcesIat, true) }}:
+
+  - stage: IatDestroy
+    dependsOn:
+    - VulnerabilityChecks
+    displayName: IAT destroy
+    jobs:
+    - template: templates/destroy-infrastructure.yml
+      parameters:
+        AzureDevOpsEnvironment: Ess-Iat
+        ShortName: iat
+        AdditionalDebugging: ${{ parameters.AdditionalDebugging }}

--- a/.azdo/pipelines/azure-pipelines.yml
+++ b/.azdo/pipelines/azure-pipelines.yml
@@ -29,22 +29,6 @@ parameters:
     displayName: "Deploy Redis"
     type: boolean
     default: true
-  - name: DestroyResourcesDev
-    displayName: "Destroy dev environment"
-    type: boolean
-    default: false
-  - name: DestroyResourcesVnextIat
-    displayName: "Destroy VnextIat environment"
-    type: boolean
-    default: false
-  - name: DestroyResourcesVnextE2E
-    displayName: "Destroy VnextE2e environment"
-    type: boolean
-    default: false
-  - name: DestroyResourcesIAT
-    displayName: "Destroy IAT environment"
-    type: boolean
-    default: false
   - name: AdditionalDebugging
     displayName: "Enable optional pipeline debugging"
     type: boolean
@@ -171,7 +155,6 @@ stages:
       parameters:
         AzureDevOpsEnvironment: Ess-Dev
         ShortName: dev
-        DestroyResources: ${{ parameters.DestroyResourcesDev }}
         AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
         DeployOrchestrator: ${{ parameters.DeployOrchestrator }}
         DeployBuilderS100: ${{ parameters.DeployBuilderS100 }}
@@ -188,7 +171,6 @@ stages:
       parameters:
         AzureDevOpsEnvironment: Ess-vnextiat
         ShortName: vnextiat
-        DestroyResources: ${{ parameters.DestroyResourcesVnextIat }}
         AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
         DeployOrchestrator: ${{ parameters.DeployOrchestrator }}
         DeployBuilderS100: ${{ parameters.DeployBuilderS100 }}
@@ -205,7 +187,6 @@ stages:
       parameters:
         AzureDevOpsEnvironment: Ess-vnexte2e
         ShortName: vnexte2e
-        DestroyResources: ${{ parameters.DestroyResourcesVnextE2E }}
         AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
         DeployOrchestrator: ${{ parameters.DeployOrchestrator }}
         DeployBuilderS100: ${{ parameters.DeployBuilderS100 }}
@@ -222,7 +203,6 @@ stages:
       parameters:
         AzureDevOpsEnvironment: Ess-iat
         ShortName: iat
-        DestroyResources: ${{ parameters.DestroyResourcesIAT }}
         AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
         DeployOrchestrator: ${{ parameters.DeployOrchestrator }}
         DeployBuilderS100: ${{ parameters.DeployBuilderS100 }}

--- a/.azdo/pipelines/templates/container-app-job-deploy.yml
+++ b/.azdo/pipelines/templates/container-app-job-deploy.yml
@@ -41,8 +41,10 @@ steps:
       $jsonData = Get-Content -Path $env:fssJson -Raw | ConvertFrom-Json
       $env:fssEndpoint = ($jsonData.endpoints | Where-Object { $_.tag -eq "" }).resolvedUrl
       $env:fssEndpointHealth = $env:fssEndpoint + "health"
+      $env:fssClientId = $jsonData.clientId
       Write-Host "##vso[task.setvariable variable=${{ parameters.BuilderType }}_FSS_ENDPOINT;]$env:fssEndpoint"
       Write-Host "##vso[task.setvariable variable=${{ parameters.BuilderType }}_FSS_ENDPOINT_HEALTH;]$env:fssEndpointHealth"
+      Write-Host "##vso[task.setvariable variable=${{ parameters.BuilderType }}_FSS_CLIENT_ID;]$env:fssClientId"
 
       $env:maxRetries = az appconfig kv list --endpoint $env:appConfigEndpoint --key "buildRequestMonitor:${{ parameters.BuilderType }}:MaxRetries" --fields value --output tsv --auth-mode login
       Write-Host "##vso[task.setvariable variable=${{ parameters.BuilderType }}_MAX_RETRY_ATTEMPTS;]$env:maxRetries"
@@ -64,7 +66,6 @@ steps:
       DEPLOYMENT_NUMBER=$EPOCHSECONDS
       DEPLOYMENT_TAG=docker-deploy-$DEPLOYMENT_NUMBER
       echo "Deployment tag - $DEPLOYMENT_TAG"
-      export CONTAINER_IMAGE="$(AcrName).azurecr.io/exchange-set-fulfilment-service/${{ parameters.AppName }}-$(AZURE_ENV_NAME):$DEPLOYMENT_TAG"
       RESOURCE_GROUP="efs-$(AZURE_ENV_NAME)-rg"
 
       echo "Reading azd variables..."
@@ -83,7 +84,12 @@ steps:
       fi
 
       echo "Logging in to Azure Container Registry..."
-      az acr login --name $(AcrName)
+      ACR_NAME="${AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN%%.*}"
+      az acr login --name $ACR_NAME
+
+      echo "Generate container image name..."
+      export CONTAINER_IMAGE="${AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}/exchange-set-fulfilment-service/${{ parameters.AppName }}-$(AZURE_ENV_NAME):$DEPLOYMENT_TAG"
+      echo $CONTAINER_IMAGE
 
       echo "Changing directory..."
       cd $(Build.SourcesDirectory)/efs/src

--- a/.azdo/pipelines/templates/continuous-deployment-retain.yml
+++ b/.azdo/pipelines/templates/continuous-deployment-retain.yml
@@ -1,0 +1,54 @@
+parameters:
+# The name of the environment to be used in Azure DevOps.
+- name: AzureDevOpsEnvironment
+  type: string
+# Used to generate job names and, in lower case, to select the correct var/x-deploy.yml variable file.
+- name: ShortName
+  type: string
+# If true, additional debugging will be enabled.
+- name: AdditionalDebugging
+  type: boolean
+  default: false
+
+jobs:
+- deployment: ${{ parameters.ShortName }}DeployResources
+  displayName: "${{ upper(parameters.ShortName) }} - deploy resources"
+  environment: ${{ parameters.AzureDevOpsEnvironment }}
+  workspace:
+    clean: all
+  variables:
+  - template: var/${{ lower(parameters.ShortName) }}-deploy.yml
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - checkout: self
+          clean: true
+          submodules: true
+
+        - download: none
+
+        - template: get-retained-resource-details.yml
+
+        - task: AzureCLI@2
+          displayName: Deploy permanent infrastructure
+          inputs:
+            azureSubscription: ${{ variables.AzureSubscription }}
+            workingDirectory: $(Build.SourcesDirectory)
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              set -e
+              echo "Deploying resources..."
+              DEPLOYMENT_NAME=$AZURE_ENV_NAME-retain-$EPOCHSECONDS
+              cd "$(Build.SourcesDirectory)/infra-retain"
+
+              if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
+                echo "Current environment variables:"
+                echo "--------------------------------------------------------------------------------"
+                env | sort
+                echo "--------------------------------------------------------------------------------"
+                az deployment sub create --name $DEPLOYMENT_NAME --location $AZURE_LOCATION --no-prompt --parameters resourceGroupName=$EFS_RETAIN_RESOURCE_GROUP efsServiceIdentityPartialName=$EFS_SERVICE_IDENTITY_PARTIAL_NAME location=$AZURE_LOCATION --template-file main.bicep --debug
+              else
+                az deployment sub create --name $DEPLOYMENT_NAME --location $AZURE_LOCATION --no-prompt --parameters resourceGroupName=$EFS_RETAIN_RESOURCE_GROUP efsServiceIdentityPartialName=$EFS_SERVICE_IDENTITY_PARTIAL_NAME location=$AZURE_LOCATION --template-file main.bicep
+              fi

--- a/.azdo/pipelines/templates/continuous-deployment.yml
+++ b/.azdo/pipelines/templates/continuous-deployment.yml
@@ -5,10 +5,6 @@ parameters:
 # Used to generate job names and, in lower case, to select the correct var/x-deploy.yml variable file.
 - name: ShortName
   type: string
-# Destroy resources, rather than deploying them.
-- name: DestroyResources
-  type: boolean
-  default: false
 # Deploy the orchestrator container app.
 - name: DeployOrchestrator
   type: boolean
@@ -73,198 +69,162 @@ jobs:
             packageType: sdk
             version: $(SdkVersion)
 
-        - ${{ if eq(parameters.DestroyResources, true) }}:
+        - task: DotNetCoreCLI@2
+          displayName: NuGet restore for non test projects only
+          inputs:
+            command: restore
+            projects: |
+              **/*.csproj
+              !**/*Tests.csproj
+            feedsToUse: config
+            noCache: true
+            nugetConfigPath: '$(Build.SourcesDirectory)/efs/BuildNuget.config'
 
-          - task: AzureCLI@2
-            displayName: Destroy infrastructure
-            inputs:
-              azureSubscription: ${{ variables.AzureSubscription }}
-              workingDirectory: $(Build.SourcesDirectory)/efs/src/UKHO.ADDS.EFS.LocalHost
-              scriptType: bash
-              scriptLocation: inlineScript
-              ${{ if eq(parameters.AdditionalDebugging, true) }}:
-                inlineScript: |
-                  azd down --no-prompt --force --purge --debug
-              ${{ else }}:
-                inlineScript: |
-                  azd down --no-prompt --force --purge
-            env:
-              AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-              AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-              AZURE_LOCATION: $(AZURE_LOCATION)
-              AZURE_SUBNET_RESOURCE_ID: $(AZURE_SUBNET_RESOURCE_ID)
+        - template: get-retained-resource-details.yml
 
-        - ${{ else }}:
+        - task: AzureCLI@2
+          displayName: Get retained infrastructure details
+          inputs:
+            azureSubscription: ${{ variables.AzureSubscription }}
+            workingDirectory: $(Build.SourcesDirectory)/efs
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              set -e
+              echo "Getting  managed identity name..."
+              EFS_SERVICE_IDENTITY_NAME=$(az identity list --resource-group $EFS_RETAIN_RESOURCE_GROUP --query "[?starts_with(name, '$(EFS_SERVICE_IDENTITY_PARTIAL_NAME)')].name" --output tsv)
 
-          - task: DotNetCoreCLI@2
-            displayName: NuGet restore for non test projects only
-            inputs:
-              command: restore
-              projects: |
-                **/*.csproj
-                !**/*Tests.csproj
-              feedsToUse: config
-              noCache: true
-              nugetConfigPath: '$(Build.SourcesDirectory)/efs/BuildNuget.config'
+              echo "Storing variables..."
+              echo "##vso[task.setvariable variable=AZURE_EFS_SERVICE_IDENTITY_RESOURCE_GROUP;]EFS_RETAIN_RESOURCE_GROUP"
+              echo "##vso[task.setvariable variable=AZURE_EFS_SERVICE_IDENTITY_NAME;]$EFS_SERVICE_IDENTITY_NAME"
 
-          - task: AzureCLI@2
-            displayName: Package application
-            inputs:
-              azureSubscription: ${{ variables.AzureSubscription }}
-              workingDirectory: $(Build.SourcesDirectory)/efs/src/UKHO.ADDS.EFS.LocalHost
-              scriptType: bash
-              scriptLocation: inlineScript
-              ${{ if eq(parameters.AdditionalDebugging, true) }}:
-                inlineScript: |
-                  set -e
-                  azd package --no-prompt --debug
+              if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
+                echo "Job variables:"
+                echo "--------------------------------------------------------------------------------"
+                echo $EFS_RETAIN_RESOURCE_GROUP
+                echo $EFS_SERVICE_IDENTITY_NAME
+                echo "--------------------------------------------------------------------------------"
+              fi
 
-                  echo "Current azd variables:"
-                  echo "--------------------------------------------------------------------------------"
-                  azd env get-values
-                  echo "--------------------------------------------------------------------------------"
-              ${{ else }}:
-                inlineScript: |
-                  azd package --no-prompt
-            env:
-              AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-              AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-              AZURE_LOCATION: $(AZURE_LOCATION)
-              AZURE_SUBNET_RESOURCE_ID: $(AZURE_SUBNET_RESOURCE_ID)
-
-          - task: AzureCLI@2
-            displayName: Deploy permanent infrastructure
-            inputs:
-              azureSubscription: ${{ variables.AzureSubscription }}
-              workingDirectory: $(Build.SourcesDirectory)/efs
-              scriptType: bash
-              scriptLocation: inlineScript
+        - task: AzureCLI@2
+          displayName: Package application
+          inputs:
+            azureSubscription: ${{ variables.AzureSubscription }}
+            workingDirectory: $(Build.SourcesDirectory)/efs/src/UKHO.ADDS.EFS.LocalHost
+            scriptType: bash
+            scriptLocation: inlineScript
+            ${{ if eq(parameters.AdditionalDebugging, true) }}:
               inlineScript: |
                 set -e
-                echo "Deploying resources..."
-                DEPLOYMENT_NAME=$AZURE_ENV_NAME-retain-$EPOCHSECONDS
-                cd "$(Build.SourcesDirectory)/efs/infra-retain"
+                azd package --no-prompt --debug
 
-                if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
-                  az deployment sub create --name $DEPLOYMENT_NAME --location $AZURE_LOCATION --no-prompt --parameters environmentName=$AZURE_ENV_NAME location=$AZURE_LOCATION --template-file main.bicep --debug
-                else
-                  az deployment sub create --name $DEPLOYMENT_NAME --location $AZURE_LOCATION --no-prompt --parameters environmentName=$AZURE_ENV_NAME location=$AZURE_LOCATION --template-file main.bicep
-                fi
+                echo "Current azd variables:"
+                echo "--------------------------------------------------------------------------------"
+                azd env get-values
+                echo "--------------------------------------------------------------------------------"
+            ${{ else }}:
+              inlineScript: |
+                azd package --no-prompt
+          env:
+            AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            AZURE_ENV_NAME: $(AZURE_ENV_NAME)
+            AZURE_LOCATION: $(AZURE_LOCATION)
+            AZURE_SUBNET_RESOURCE_ID: $(AZURE_SUBNET_RESOURCE_ID)
 
-                echo "Retrieving outputs..."
-                EFS_SERVICE_IDENTITY_RESOURCE_GROUP=$(az deployment sub show --name $DEPLOYMENT_NAME --query properties.outputs.efS_SERVICE_IDENTITY_RESOURCE_GROUP.value --output tsv)
-                EFS_SERVICE_IDENTITY_NAME=$(az deployment sub show --name $DEPLOYMENT_NAME --query properties.outputs.efS_SERVICE_IDENTITY_NAME.value --output tsv)
-
-                echo "Storing variables..."
-                echo "##vso[task.setvariable variable=AZURE_EFS_SERVICE_IDENTITY_RESOURCE_GROUP;]$EFS_SERVICE_IDENTITY_RESOURCE_GROUP"
-                echo "##vso[task.setvariable variable=AZURE_EFS_SERVICE_IDENTITY_NAME;]$EFS_SERVICE_IDENTITY_NAME"
-
-                if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
-                  echo "Job variables:"
-                  echo "--------------------------------------------------------------------------------"
-                  echo $EFS_SERVICE_IDENTITY_RESOURCE_GROUP
-                  echo $EFS_SERVICE_IDENTITY_NAME
-                  echo "--------------------------------------------------------------------------------"
-                fi
-            env:
-              AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-              AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-              AZURE_LOCATION: $(AZURE_LOCATION)
-
-          - task: AzureCLI@2
-            displayName: Provision infrastructure
-            inputs:
-              azureSubscription: ${{ variables.AzureSubscription }}
-              workingDirectory: $(Build.SourcesDirectory)/efs/src/UKHO.ADDS.EFS.LocalHost
-              scriptType: bash
-              scriptLocation: inlineScript
-              ${{ if eq(parameters.AdditionalDebugging, true) }}:
-                inlineScript: |
-                  set -e
-                  azd provision --no-prompt --debug
-
-                  echo "Current azd variables:"
-                  echo "--------------------------------------------------------------------------------"
-                  azd env get-values
-                  echo "--------------------------------------------------------------------------------"
-              ${{ else }}:
-                inlineScript: |
-                  azd provision --no-prompt
-            env:
-              AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-              AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-              AZURE_LOCATION: $(AZURE_LOCATION)
-              AZURE_SUBNET_RESOURCE_ID: $(AZURE_SUBNET_RESOURCE_ID)
-              AZURE_ADDS_ENVIRONMENT: $(AZURE_ENV_NAME)
-              AZURE_EFS_SERVICE_IDENTITY_RESOURCE_GROUP: $(AZURE_EFS_SERVICE_IDENTITY_RESOURCE_GROUP)
-              AZURE_EFS_SERVICE_IDENTITY_NAME: $(AZURE_EFS_SERVICE_IDENTITY_NAME)
-
-          - task: AzureCLI@2
-            displayName: Run configuration seeder
-            inputs:
-              azureSubscription: ${{ variables.AzureSubscription }}
-              workingDirectory: $(Build.SourcesDirectory)/efs/src/UKHO.ADDS.EFS.LocalHost
-              scriptType: bash
-              scriptLocation: inlineScript
+        - task: AzureCLI@2
+          displayName: Provision infrastructure
+          inputs:
+            azureSubscription: ${{ variables.AzureSubscription }}
+            workingDirectory: $(Build.SourcesDirectory)/efs/src/UKHO.ADDS.EFS.LocalHost
+            scriptType: bash
+            scriptLocation: inlineScript
+            ${{ if eq(parameters.AdditionalDebugging, true) }}:
               inlineScript: |
                 set -e
-                echo "Reading azd variables..."
-                while IFS='=' read -r key value; do
-                    value=$(echo "$value" | sed 's/^"//' | sed 's/"$//')
-                    export "$key=$value"
-                done <<EOF
-                $(azd env get-values)
-                EOF
+                azd provision --no-prompt --debug
 
-                if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
-                  echo "Current environment variables:"
-                  echo "--------------------------------------------------------------------------------"
-                  env | sort
-                  echo "--------------------------------------------------------------------------------"
-                fi
+                echo "Current azd variables:"
+                echo "--------------------------------------------------------------------------------"
+                azd env get-values
+                echo "--------------------------------------------------------------------------------"
+            ${{ else }}:
+              inlineScript: |
+                azd provision --no-prompt
+          env:
+            AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            AZURE_ENV_NAME: $(AZURE_ENV_NAME)
+            AZURE_LOCATION: $(AZURE_LOCATION)
+            AZURE_SUBNET_RESOURCE_ID: $(AZURE_SUBNET_RESOURCE_ID)
+            AZURE_ADDS_ENVIRONMENT: $(AZURE_ENV_NAME)
+            AZURE_EFS_SERVICE_IDENTITY_RESOURCE_GROUP: $(AZURE_EFS_SERVICE_IDENTITY_RESOURCE_GROUP)
+            AZURE_EFS_SERVICE_IDENTITY_NAME: $(AZURE_EFS_SERVICE_IDENTITY_NAME)
 
-                sed -i "s/{{cae_domain}}/${AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}/g" "$(Build.SourcesDirectory)/efs/configuration/external-services.json"
+        - task: AzureCLI@2
+          displayName: Run configuration seeder
+          inputs:
+            azureSubscription: ${{ variables.AzureSubscription }}
+            workingDirectory: $(Build.SourcesDirectory)/efs/src/UKHO.ADDS.EFS.LocalHost
+            scriptType: bash
+            scriptLocation: inlineScript
+            inlineScript: |
+              set -e
+              echo "Reading azd variables..."
+              while IFS='=' read -r key value; do
+                  value=$(echo "$value" | sed 's/^"//' | sed 's/"$//')
+                  export "$key=$value"
+              done <<EOF
+              $(azd env get-values)
+              EOF
 
-                if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
-                  echo "external-services.json:"
-                  echo "--------------------------------------------------------------------------------"
-                  cat "$(Build.SourcesDirectory)/efs/configuration/external-services.json"
-                  echo "--------------------------------------------------------------------------------"
-                fi
+              if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
+                echo "Current environment variables:"
+                echo "--------------------------------------------------------------------------------"
+                env | sort
+                echo "--------------------------------------------------------------------------------"
+              fi
 
-                dotnet run --project $(Build.SourcesDirectory)/efs/configuration/UKHO.ADDS.Aspire.Configuration.Seeder/UKHO.ADDS.Aspire.Configuration.Seeder.csproj --configuration Release --no-restore -- "efs" "$(AZURE_ENV_NAME)" "$(Build.SourcesDirectory)/efs/configuration/configuration.json" "$(Build.SourcesDirectory)/efs/configuration/external-services.json" "$EFS_APPCONFIG_APPCONFIGENDPOINT"
-            env:
-              AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
-              AZURE_ENV_NAME: $(AZURE_ENV_NAME)
-              AZURE_LOCATION: $(AZURE_LOCATION)
-              AZURE_SUBNET_RESOURCE_ID: $(AZURE_SUBNET_RESOURCE_ID)
+              sed -i "s/{{cae_domain}}/${AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN}/g" "$(Build.SourcesDirectory)/efs/configuration/external-services.json"
 
-          - template: container-app-deploy.yml
-            parameters:
-              AzureSubscription: ${{ variables.AzureSubscription }}
-              AppName: efs-redis
-              AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
-              DeployApp: ${{ parameters.DeployRedis }}
+              if [ "${{ parameters.AdditionalDebugging }}" == "True" ]; then
+                echo "external-services.json:"
+                echo "--------------------------------------------------------------------------------"
+                cat "$(Build.SourcesDirectory)/efs/configuration/external-services.json"
+                echo "--------------------------------------------------------------------------------"
+              fi
 
-          - template: container-app-deploy.yml
-            parameters:
-              AzureSubscription: ${{ variables.AzureSubscription }}
-              AppName: adds-mocks-efs
-              AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
-              DeployApp: ${{ parameters.DeployAddsMock }}
+              dotnet run --project $(Build.SourcesDirectory)/efs/configuration/UKHO.ADDS.Aspire.Configuration.Seeder/UKHO.ADDS.Aspire.Configuration.Seeder.csproj --configuration Release --no-restore -- "efs" "$(AZURE_ENV_NAME)" "$(Build.SourcesDirectory)/efs/configuration/configuration.json" "$(Build.SourcesDirectory)/efs/configuration/external-services.json" "$EFS_APPCONFIG_APPCONFIGENDPOINT"
+          env:
+            AZURE_SUBSCRIPTION_ID: $(AZURE_SUBSCRIPTION_ID)
+            AZURE_ENV_NAME: $(AZURE_ENV_NAME)
+            AZURE_LOCATION: $(AZURE_LOCATION)
+            AZURE_SUBNET_RESOURCE_ID: $(AZURE_SUBNET_RESOURCE_ID)
 
-          - template: container-app-deploy.yml
-            parameters:
-              AzureSubscription: ${{ variables.AzureSubscription }}
-              AppName: efs-orchestrator
-              AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
-              DeployApp: ${{ parameters.DeployOrchestrator }}
+        - template: container-app-deploy.yml
+          parameters:
+            AzureSubscription: ${{ variables.AzureSubscription }}
+            AppName: efs-redis
+            AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+            DeployApp: ${{ parameters.DeployRedis }}
 
-          - template: container-app-job-deploy.yml
-            parameters:
-              AzureSubscription: ${{ variables.AzureSubscription }}
-              AppName: efs-builder-s100
-              ProjectFolder: UKHO.ADDS.EFS.Builder.S100
-              BuilderType: S100
-              AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
-              DeployApp: ${{ parameters.DeployBuilderS100 }}
+        - template: container-app-deploy.yml
+          parameters:
+            AzureSubscription: ${{ variables.AzureSubscription }}
+            AppName: adds-mocks-efs
+            AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+            DeployApp: ${{ parameters.DeployAddsMock }}
+
+        - template: container-app-deploy.yml
+          parameters:
+            AzureSubscription: ${{ variables.AzureSubscription }}
+            AppName: efs-orchestrator
+            AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+            DeployApp: ${{ parameters.DeployOrchestrator }}
+
+        - template: container-app-job-deploy.yml
+          parameters:
+            AzureSubscription: ${{ variables.AzureSubscription }}
+            AppName: efs-builder-s100
+            ProjectFolder: UKHO.ADDS.EFS.Builder.S100
+            BuilderType: S100
+            AdditionalDebugging: ${{ parameters.AdditionalDebugging }}
+            DeployApp: ${{ parameters.DeployBuilderS100 }}

--- a/.azdo/pipelines/templates/destroy-infrastructure.yml
+++ b/.azdo/pipelines/templates/destroy-infrastructure.yml
@@ -1,0 +1,49 @@
+parameters:
+# The name of the environment to be used in Azure DevOps.
+- name: AzureDevOpsEnvironment
+  type: string
+# Used to generate job names and, in lower case, to select the correct var/x-deploy.yml variable file.
+- name: ShortName
+  type: string
+# If true, additional debugging will be enabled.
+- name: AdditionalDebugging
+  type: boolean
+  default: false
+
+jobs:
+- deployment: ${{ parameters.ShortName }}DestroyResourceGroup
+  displayName: "${{ upper(parameters.ShortName) }} - destroy"
+  environment: ${{ parameters.AzureDevOpsEnvironment }}
+  workspace:
+    clean: all
+  variables:
+  - template: var/${{ lower(parameters.ShortName) }}-deploy.yml
+  strategy:
+    runOnce:
+      deploy:
+        steps:
+        - checkout: self
+          clean: true
+          submodules: true
+
+        - download: none
+  
+        - script: |
+            curl -fsSL https://aka.ms/install-azd.sh | bash
+            azd version
+            azd config set auth.useAzCliAuth "true"
+          displayName: Install azd
+
+        - task: AzureCLI@2
+          displayName: Destroy infrastructure
+          inputs:
+            azureSubscription: ${{ variables.AzureSubscription }}
+            workingDirectory: $(Build.SourcesDirectory)/src/UKHO.ADDS.EFS.LocalHost
+            scriptType: bash
+            scriptLocation: inlineScript
+            ${{ if eq(parameters.AdditionalDebugging, true) }}:
+              inlineScript: |
+                azd down --no-prompt --force --purge --debug
+            ${{ else }}:
+              inlineScript: |
+                azd down --no-prompt --force --purge

--- a/.azdo/pipelines/templates/get-retained-resource-details.yml
+++ b/.azdo/pipelines/templates/get-retained-resource-details.yml
@@ -1,0 +1,5 @@
+steps:
+- script: |
+    echo "##vso[task.setvariable variable=EFS_RETAIN_RESOURCE_GROUP;]efs-$(AZURE_ENV_NAME)-retain-rg"
+    echo "##vso[task.setvariable variable=EFS_SERVICE_IDENTITY_PARTIAL_NAME;]efs_service_identity"
+  displayName: Set retained resource variables

--- a/.azdo/pipelines/templates/vulnerability-checks.yml
+++ b/.azdo/pipelines/templates/vulnerability-checks.yml
@@ -5,28 +5,34 @@ parameters:
 - name: SnykPassOnIssues
   type: boolean
   default: false
+- name: IacOnly
+  type: boolean
+  default: false
 
 jobs:
 - job: Snyk
   displayName: Run Snyk security scans
   pool: $(WindowsPool)
   steps:
-  - task: UseDotNet@2
-    displayName: Use .NET SDK $(SdkVersion)
-    inputs:
-      packageType: sdk
-      version: $(SdkVersion)
 
-  - task: DotNetCoreCLI@2
-    displayName: .NET - NuGet restore
-    inputs:
-      command: restore
-      projects: |
-        **/*.csproj
-      feedsToUse: config
-      noCache: true
-      nugetConfigPath: '$(Build.SourcesDirectory)\BuildNuget.config'
-      workingDirectory: '$(Build.SourcesDirectory)'
+  - ${{ if ne(parameters.IacOnly, true) }}:
+
+    - task: UseDotNet@2
+      displayName: Use .NET SDK $(SdkVersion)
+      inputs:
+        packageType: sdk
+        version: $(SdkVersion)
+
+    - task: DotNetCoreCLI@2
+      displayName: .NET - NuGet restore
+      inputs:
+        command: restore
+        projects: |
+          **/*.csproj
+        feedsToUse: config
+        noCache: true
+        nugetConfigPath: '$(Build.SourcesDirectory)\BuildNuget.config'
+        workingDirectory: '$(Build.SourcesDirectory)'
 
   - pwsh: |
       mkdir "$(Agent.TempDirectory)\$(Build.BuildId)"
@@ -48,33 +54,35 @@ jobs:
       ${{ if eq(parameters.SnykOnlyFailIfFixable, true) }}:
         additionalArguments: --fail-on=all
 
-  - task: UkhoSnykScanTask@0
-    displayName: Snyk SAST scan
-    condition: succeededOrFailed()
-    inputs:
-      failOnIssues: ${{ not(parameters.SnykPassOnIssues) }}
-      failOnThreshold: high
-      organization: $(snykAbzuOrganizationId)
-      serviceConnectionEndpoint: Snyk
-      codeSeverityThreshold: low
-      testType: code
-      monitorwhen: never
-      ${{ if eq(parameters.SnykOnlyFailIfFixable, true) }}:
-        additionalArguments: --fail-on=all
+  - ${{ if ne(parameters.IacOnly, true) }}:
 
-  - task: UkhoSnykScanTask@0
-    displayName: Snyk SCA scan
-    condition: succeededOrFailed()
-    inputs:
-      failOnIssues: ${{ not(parameters.SnykPassOnIssues) }}
-      failOnThreshold: high
-      organization: $(snykAbzuOrganizationId)
-      serviceConnectionEndpoint: Snyk
-      codeSeverityThreshold: low
-      testType: app
-      monitorwhen: never
-      severityThreshold: low
-      ${{ if eq(parameters.SnykOnlyFailIfFixable, true) }}:
-        additionalArguments: --all-projects --fail-on=all
-      ${{ else }}:
-        additionalArguments: --all-projects
+    - task: UkhoSnykScanTask@0
+      displayName: Snyk SAST scan
+      condition: succeededOrFailed()
+      inputs:
+        failOnIssues: ${{ not(parameters.SnykPassOnIssues) }}
+        failOnThreshold: high
+        organization: $(snykAbzuOrganizationId)
+        serviceConnectionEndpoint: Snyk
+        codeSeverityThreshold: low
+        testType: code
+        monitorwhen: never
+        ${{ if eq(parameters.SnykOnlyFailIfFixable, true) }}:
+          additionalArguments: --fail-on=all
+
+    - task: UkhoSnykScanTask@0
+      displayName: Snyk SCA scan
+      condition: succeededOrFailed()
+      inputs:
+        failOnIssues: ${{ not(parameters.SnykPassOnIssues) }}
+        failOnThreshold: high
+        organization: $(snykAbzuOrganizationId)
+        serviceConnectionEndpoint: Snyk
+        codeSeverityThreshold: low
+        testType: app
+        monitorwhen: never
+        severityThreshold: low
+        ${{ if eq(parameters.SnykOnlyFailIfFixable, true) }}:
+          additionalArguments: --all-projects --fail-on=all
+        ${{ else }}:
+          additionalArguments: --all-projects

--- a/infra-retain/efs-service-identity/efs-service-identity.module.bicep
+++ b/infra-retain/efs-service-identity/efs-service-identity.module.bicep
@@ -1,8 +1,12 @@
 @description('The location for the resource(s) to be deployed.')
 param location string = resourceGroup().location
 
+@minLength(1)
+@description('The partial name (from the start) of the service identity resource.')
+param efsServiceIdentityPartialName string
+
 resource efs_service_identity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: take('efs_service_identity-${uniqueString(resourceGroup().id)}', 128)
+  name: take('${efsServiceIdentityPartialName}-${uniqueString(resourceGroup().id)}', 128)
   location: location
   tags: {
     'hidden-title': 'EFS'

--- a/infra-retain/main.bicep
+++ b/infra-retain/main.bicep
@@ -2,15 +2,19 @@ targetScope = 'subscription'
 
 @minLength(1)
 @maxLength(64)
-@description('Name of the environment that can be used as part of naming resource convention. The name of the resource group for your application will include this name.')
-param environmentName string
+@description('Name of the resource group for fixed resources.')
+param resourceGroupName string
+
+@minLength(1)
+@description('The partial name (from the start) of the service identity resource.')
+param efsServiceIdentityPartialName string
 
 @minLength(1)
 @description('The location used for all deployed resources')
 param location string
 
 resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
-  name: 'efs-${environmentName}-retain-rg'
+  name: resourceGroupName
   location: location
 }
 
@@ -19,6 +23,7 @@ module efs_service_identity 'efs-service-identity/efs-service-identity.module.bi
   scope: rg
   params: {
     location: location
+    efsServiceIdentityPartialName: efsServiceIdentityPartialName
   }
 }
 


### PR DESCRIPTION
#### PR Classification
Enhancement of Azure DevOps pipeline to separate initial setup from general deployment.

#### PR Summary
Create a new admin pipeline for the following functions:
- Deploy retained infrastructure such as the managed identity for the service to use. This is set up in the `rg-{env}-retain-rg` resource group.
- Destroy the infrastructure contained in the `rg-{env}-rg` resource group.
- These functions have been moved from `azure-pipeline.yml` to the new pipeline `azure-pipelines-admin.yml`.