### PR TITLE
Turn on local auth for Elastic

### DIFF
--- a/src/UKHO.ADDS.EFS.LocalHost/Program.cs
+++ b/src/UKHO.ADDS.EFS.LocalHost/Program.cs
@@ -124,6 +124,7 @@ namespace UKHO.ADDS.EFS.LocalHost
                 {
                     var eventHubNamespace = config.GetProvisionableResources().OfType<EventHubsNamespace>().Single();
                     eventHubNamespace.Tags.Add("hidden-title", ServiceConfiguration.ServiceName);
+                    eventHubNamespace.DisableLocalAuth = false;
                 });
                 eventHubs.AddHub(ServiceConfiguration.EventHubName);
             }

--- a/src/UKHO.ADDS.EFS.LocalHost/infra/efs-events-namespace/efs-events-namespace.module.bicep
+++ b/src/UKHO.ADDS.EFS.LocalHost/infra/efs-events-namespace/efs-events-namespace.module.bicep
@@ -7,7 +7,7 @@ resource efs_events_namespace 'Microsoft.EventHub/namespaces@2024-01-01' = {
   name: take('efs-events-namespace-${uniqueString(resourceGroup().id)}', 256)
   location: location
   properties: {
-    disableLocalAuth: true
+    disableLocalAuth: false
   }
   sku: {
     name: sku


### PR DESCRIPTION
#### PR Classification
The changes enable local authentication for the Azure Event Hub namespace.

#### PR Summary
This pull request modifies the configuration of the Azure Event Hub namespace to allow local authentication by updating relevant properties in the code and infrastructure definition.
- `Program.cs`: Added line to set `DisableLocalAuth` to `false`.
- `efs-events-namespace.module.bicep`: Changed `disableLocalAuth` from `true` to `false`.
