### PR TITLE
Abzu 287177 retain pipeline

### DIFF
--- a/.azdo/pipelines/azure-pipelines.yml
+++ b/.azdo/pipelines/azure-pipelines.yml
@@ -168,7 +168,6 @@ stages:
         DeployAddsMock: ${{ parameters.DeployAddsMock }}
         IncludeAddsMock: true
         DeployRedis: ${{ parameters.DeployRedis }}
-        RetainPipeline: true
 
   - stage: vnextiatDeploy
     dependsOn:

--- a/.azdo/pipelines/azure-pipelines.yml
+++ b/.azdo/pipelines/azure-pipelines.yml
@@ -74,7 +74,12 @@ resources:
     type: github
     endpoint: ukho
     name: ukho/devops-trigger-adds-autotest-pipeline
-    ref: refs/heads/main 
+    ref: refs/heads/main
+  - repository: UKHOTemplates
+    type: github
+    name: UKHO/devops-pipelinetemplates
+    endpoint: UKHO
+    ref: refs/heads/main
 
 stages:
   - stage: VulnerabilityChecks
@@ -163,6 +168,7 @@ stages:
         DeployAddsMock: ${{ parameters.DeployAddsMock }}
         IncludeAddsMock: true
         DeployRedis: ${{ parameters.DeployRedis }}
+        RetainPipeline: true
 
   - stage: vnextiatDeploy
     dependsOn:
@@ -252,3 +258,4 @@ stages:
         IncludeAddsMock: false
         DeployRedis: ${{ parameters.DeployRedis }}
         IICWorkspace: live
+        RetainPipeline: true

--- a/.azdo/pipelines/templates/continuous-deployment.yml
+++ b/.azdo/pipelines/templates/continuous-deployment.yml
@@ -44,6 +44,10 @@ parameters:
   values:
   - 'live'
   - 'dev'
+# Set the pipeline retention period. Typically used after a successful live deployment.
+- name: RetainPipeline
+  type: boolean
+  default: false
 
 jobs:
 - deployment: ${{ parameters.ShortName }}DeployApp
@@ -325,3 +329,15 @@ jobs:
       environment: ${{ parameters.RunAddsTests }}
       dependsOn:
       - ${{ parameters.ShortName }}DeployApp
+
+- ${{ if eq(parameters.RetainPipeline, true) }}:
+  - job: ${{ parameters.ShortName }}RetainPipeline
+    displayName: ${{ upper(parameters.ShortName) }} - retain pipeline
+    dependsOn:
+    - ${{ parameters.ShortName }}DeployApp
+    steps:
+    - checkout: UKHOTemplates
+    - template: retain-pipelinerun/retain-pipelinerun.yml@UKHOTemplates
+      parameters:
+        DaysValid: 365
+


### PR DESCRIPTION
This pull request introduces improvements to the Azure DevOps pipeline configuration by integrating a new pipeline retention feature and referencing shared pipeline templates. The main goal is to allow retention of pipeline runs (for up to 365 days) after successful live deployments, using a new parameter and job. Additionally, the pipeline now leverages external template resources for better maintainability.

**Pipeline retention feature:**

* Added a new boolean parameter `RetainPipeline` (default `false`) to `continuous-deployment.yml`, enabling conditional retention of pipeline runs after deployment.
* Introduced a new job that, when `RetainPipeline` is `true`, checks out the shared `UKHOTemplates` repository and invokes the `retain-pipelinerun` template to retain the pipeline run for 365 days.
* Updated the main pipeline (`azure-pipelines.yml`) to pass `RetainPipeline: true` when deploying to the live environment.

**Template and resource integration:**

* Added the `UKHOTemplates` GitHub repository as a pipeline resource, allowing the use of shared pipeline templates.