### PR TITLE
Added retain pipeline job at the end of the Live deployment.

### DIFF
--- a/.azdo/pipelines/azure-pipelines-admin.yml
+++ b/.azdo/pipelines/azure-pipelines-admin.yml
@@ -64,6 +64,14 @@ variables:
 - name: Container
   value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.13.0"
 
+resources:
+  repositories:
+  - repository: UKHOTemplates
+    type: github
+    name: UKHO/devops-pipelinetemplates
+    endpoint: UKHO
+    ref: refs/heads/main
+
 stages:
 - stage: VulnerabilityChecks
   displayName: Checks
@@ -144,6 +152,16 @@ stages:
           ShortName: Live
           ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
           ContainerImage: ${{ variables.Container }}
+
+    - job: LiveRetainPipeline
+      displayName: LIVE - retain pipeline
+      dependsOn:
+      - LiveAPIMDeploy
+      steps:
+      - checkout: UKHOTemplates
+      - template: retain-pipelinerun/retain-pipelinerun.yml@UKHOTemplates
+        parameters:
+          DaysValid: 730
 
   - stage: vNextIatDeploy
     dependsOn:


### PR DESCRIPTION
This pull request updates the Azure Pipelines configuration to integrate shared pipeline templates from a central repository and adds a new job for pipeline retention in the live environment. The most important changes are:

**Integration of shared pipeline templates:**

* Added a new resource repository reference to `UKHO/devops-pipelinetemplates` in the `resources` section, allowing the pipeline to use shared templates maintained by UKHO.

**Pipeline retention improvements:**

* Introduced a new job, `LiveRetainPipeline`, which runs after the `LiveAPIMDeploy` job. This job checks out the shared templates repository and uses the `retain-pipelinerun` template to retain the pipeline run for 730 days, improving auditability and traceability of live deployments.